### PR TITLE
add progress-bar styles

### DIFF
--- a/app/assets/stylesheets/forever_style_guide/modules/_all.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_all.scss
@@ -11,3 +11,4 @@
 @import "select";
 @import "checkbox";
 @import "hero";
+@import "progress";

--- a/app/assets/stylesheets/forever_style_guide/modules/_progress.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_progress.scss
@@ -1,0 +1,37 @@
+$progress-rounding: 10px;
+
+.progress {
+  height: 15px;
+  border-radius: $progress-rounding;
+  background-color: $color-background;
+}
+
+.progress-bar,
+.progress-bar-default {
+  line-height: 17px; // line height centers the label vertically
+  text-align: right;
+  background-color: $color-secondary;
+  border-top-right-radius: $progress-rounding;
+  border-bottom-right-radius: $progress-rounding;
+
+  .progress-label {
+    padding-right: 5px;
+  }
+}
+.progress-bar-success,
+.progress-bar-primary {
+  background-color: $color-primary;
+}
+.progress-bar-info,
+.progress-bar-secondary {
+  background-color: $color-secondary;
+}
+.progress-bar-accent {
+  background-color: $color-accent;
+}
+.progress-bar-warning {
+  background-color: $color-warning;
+}
+.progress-bar-danger {
+  background-color: $color-danger;
+}

--- a/app/views/forever_style_guide/sections/visual_elements/_progress.erb
+++ b/app/views/forever_style_guide/sections/visual_elements/_progress.erb
@@ -1,0 +1,73 @@
+<label>Default - .progress-bar, .progress-bar-default</label>
+<div class="progress">
+  <div class="progress-bar" role="progressbar" aria-valuenow="65" aria-valuemin="0" aria-valuemax="100" style="width: 65%">
+    <span class="progress-label">65%</span>
+  </div>
+</div>
+
+<label>Success - .progress-bar-success, .progress-bar-primary</label>
+<div class="progress">
+  <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100" style="width: 40%">
+    <span class="progress-label">40%</span>
+  </div>
+</div>
+
+<label>Info - .progress-bar-info, .progress-bar-secondary</label>
+<div class="progress">
+  <div class="progress-bar progress-bar-info" role="progressbar" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100" style="width: 20%">
+    <span class="progress-label">20%</span>
+  </div>
+</div>
+
+<label>Accent - .progress-bar-accent</label>
+<div class="progress">
+  <div class="progress-bar progress-bar-accent" role="progressbar" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100" style="width: 20%">
+    <span class="progress-label">20%</span>
+  </div>
+</div>
+
+<label>Warning - .progress-bar-warning</label>
+<div class="progress">
+  <div class="progress-bar progress-bar-warning" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%">
+    <span class="progress-label">60%</span>
+  </div>
+</div>
+
+<label>Danger - .progress-bar-danger</label>
+<div class="progress">
+  <div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
+    <span class="progress-label">80%</span>
+  </div>
+</div>
+
+<hr />
+
+<label>Striped</label>
+<div class="progress">
+  <div class="progress-bar progress-bar-striped" role="progressbar" aria-valuenow="65" aria-valuemin="0" aria-valuemax="100" style="width: 65%">
+    <span class="progress-label">40%</span>
+  </div>
+</div>
+<div class="progress">
+  <div class="progress-bar progress-bar-success progress-bar-striped" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100" style="width: 40%">
+    <span class="progress-label">40%</span>
+  </div>
+</div>
+<div class="progress">
+  <div class="progress-bar progress-bar-warning progress-bar-striped" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%">
+    <span class="progress-label">60%</span>
+  </div>
+</div>
+<div class="progress">
+  <div class="progress-bar progress-bar-danger progress-bar-striped" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
+    <span class="progress-label">80%</span>
+  </div>
+</div>
+
+<hr />
+<label>Animated - .active</label>
+<div class="progress">
+  <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="45" aria-valuemin="0" aria-valuemax="100" style="width: 45%">
+    <span class="progress-label">45%</span>
+  </div>
+</div>


### PR DESCRIPTION
Some minor visual tweaks, but mostly just making sure progress bars use Forever brand colors.

![screen shot 2015-07-07 at 5 21 53 pm](https://cloud.githubusercontent.com/assets/3814998/8557633/96f6a1e4-24cc-11e5-9b35-a0fbae52cfc8.png)
