### PR TITLE
create sawtooth effect for each of the core colors

### DIFF
--- a/app/assets/stylesheets/forever_style_guide/globals/_effects.scss
+++ b/app/assets/stylesheets/forever_style_guide/globals/_effects.scss
@@ -94,3 +94,39 @@ $color-card-bg: color('white');
   @include transition-property(background-color, color);
   @include transition-duration(0.3s);
 }
+
+// creates a sawtooth banner style for each color in core color dictionary
+@each $id, $color in $core_colors {
+  $sawtooth-size: 8px;
+  $sawtooth-border: 15px;
+
+  %sawtooth-#{$id} {
+    position: relative;
+    background: color('#{$id}-light');
+
+    &:before, &:after {
+      content:'';
+      width:100%;
+      height: $sawtooth-size + $sawtooth-border;
+      position: absolute;
+      bottom: 100%;
+      left: 0;
+      background-image: linear-gradient(135deg, transparent 66%, color('#{$id}') 67%),
+      linear-gradient(45deg, color('#{$id}') 33%, color('#{$id}-dark') 34%, transparent 44%);
+      background-position: -$sawtooth-size 0;
+      background-size: ($sawtooth-size * 2) 100%;
+      background-repeat: repeat-x;
+    }
+    &:after {
+      top: 100%;
+      bottom: auto;
+      background-image: linear-gradient(135deg, color('#{$id}') 33%, color('#{$id}-dark') 34%, transparent 44%),
+      linear-gradient(45deg, transparent 66%, color('#{$id}') 67%);
+      border-top: solid $sawtooth-border color('#{$id}');
+    }
+    &:before {
+      border-bottom: solid $sawtooth-border color('#{$id}');
+    }
+  }
+}
+


### PR DESCRIPTION
Creates a placeholder style for each of the core colors so you can include the sawtooth banner visual effect via ```@extend %sawtooth-historian;``` etc.