### PR TITLE
add general use roman list style

### DIFF
--- a/app/assets/stylesheets/forever_style_guide/modules/_list.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_list.scss
@@ -65,3 +65,8 @@
     margin: 0;
   }
 }
+
+.list-roman {
+  list-style: lower-roman;
+  list-style-position: outside;
+}

--- a/app/views/forever_style_guide/sections/visual_elements/_lists.erb
+++ b/app/views/forever_style_guide/sections/visual_elements/_lists.erb
@@ -39,6 +39,15 @@
   <li class="list-benefit">Vestibulum at eros</li>
 </ul>
 <hr>
+<label>Ordered Roman List - for use in official policies, terms of service, etc</label>
+<ol class="list-roman">
+  <li>an “Account Originator” ...</li>
+  <li>a “Guaranteed Member”...</li>
+  <li>one or more “Account Managers”...</li>
+  <li>a Guaranteed Account (formerly called a Permanent Account) </li>
+  <li>a Free Account, (formerly called an Introductory (“Intro”) Account) by registering</li>
+</ol>
+<hr>
 <label>List Groups</label>
 <ul class="list-group">
   <li class="list-group-item">Cras justo odio</li>


### PR DESCRIPTION
Adds a basic ordered list w/ roman numerals for use in official capacities (ex. terms of service)

![screen shot 2015-09-11 at 11 44 05 am](https://cloud.githubusercontent.com/assets/3814998/9819171/7da73104-587a-11e5-8e9e-2147ff9b4d54.png)
