### PR TITLE
make sure account popover closes when toggle nav closes

### DIFF
--- a/app/assets/javascripts/forever_style_guide/nav-fixed.js
+++ b/app/assets/javascripts/forever_style_guide/nav-fixed.js
@@ -13,12 +13,21 @@ $(function () {
     }, 250);
     $('.popover.account-popover').popover('hide');
   })
+
+  // unfix body on dropdown close
   $('#header-is_fixed .dropdown').on('hidden.bs.dropdown', function () {
     $('body').removeClass('body-fixed');
     $('#header-is_fixed').removeClass('is_scrolling');
   })
+
+  // unfix body on toggle nav close
   $('#header-is_fixed #collapse-nav').on('hidden.bs.collapse', function () {
     $('body').removeClass('body-fixed');
     $('#header-is_fixed').removeClass('is_scrolling');
+  })
+
+  // hide account popover on toggle nav close
+  $('#header-is_fixed #collapse-nav').on('hide.bs.collapse', function () {
+    $('.popover.account-popover').popover('hide');
   })
 });


### PR DESCRIPTION
This was inadvertently omitted when adding the signed in state to the fixed header nav.

We need to make sure that when we close the toggle menu the account popover closes as well. Also added some comments here to make this clearer.