### PR TITLE
add a state style for the footer security assurance

### DIFF
--- a/app/assets/stylesheets/forever_style_guide/modules/_footer.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_footer.scss
@@ -46,6 +46,9 @@
     a {
       display: block;
     }
+    &.is_top {
+      margin-top: 0;
+    }
   }
   .security_assurance-icon {
     width: 20%;


### PR DESCRIPTION
Minor state style for making the security assurance the "top" item in it's column for when we conditionally hide the registration button for logged in users.

##Logged in
![screen shot 2015-09-15 at 2 58 17 pm](https://cloud.githubusercontent.com/assets/3814998/9886836/5b4c56dc-5bba-11e5-85e6-66ecf315b55b.png)

##Logged out (.security-assurance .is_top)
![screen shot 2015-09-15 at 2 58 06 pm](https://cloud.githubusercontent.com/assets/3814998/9886848/6f3607ba-5bba-11e5-8815-73960841aacd.png)
