### PR TITLE
Bug/explicit logo width

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    forever_style_guide (1.2.8)
+    forever_style_guide (1.2.9)
       bootstrap-sass
       compass-rails
       font-awesome-rails
@@ -70,9 +70,9 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
-    compass-rails (2.0.4)
+    compass-rails (2.0.5)
       compass (~> 1.0.0)
-      sass-rails (<= 5.0.1)
+      sass-rails (< 5.1)
       sprockets (< 2.13)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
@@ -170,12 +170,12 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     sass (3.4.19)
-    sass-rails (5.0.1)
+    sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
-      tilt (~> 1.1)
+      tilt (>= 1.1, < 3)
     shellany (0.0.1)
     slop (3.6.0)
     sprockets (2.12.4)
@@ -208,3 +208,6 @@ DEPENDENCIES
   rack-livereload
   sqlite3
   thor
+
+BUNDLED WITH
+   1.10.6

--- a/app/assets/stylesheets/forever_style_guide/modules/_navbar.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_navbar.scss
@@ -28,8 +28,7 @@
     height: $header_height;
 
     .navbar-brand-logo {
-      max-width: 190px;
-      max-height: 50px;
+      width: 190px;
     }
   }
 

--- a/app/assets/stylesheets/forever_style_guide/modules/_navbar.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_navbar.scss
@@ -24,7 +24,7 @@
 
   .navbar-brand {
     display: block;
-    padding: 10px 30px 10px 10px;
+    padding: 10px 0 10px 10px;
     height: $header_height;
 
     .navbar-brand-logo {

--- a/lib/forever_style_guide/version.rb
+++ b/lib/forever_style_guide/version.rb
@@ -1,3 +1,3 @@
 module ForeverStyleGuide
-  VERSION = "1.2.8"
+  VERSION = "1.2.9"
 end


### PR DESCRIPTION
As the nav and logo are always the same we are free to be more explicit here. I encountered an issue where entering a native iOS text or other field performs a zoom that resulted in the logo wrapping to another line separate of the toggle.


![img_0948 2](https://cloud.githubusercontent.com/assets/3814998/11309774/bfdcb5da-8f93-11e5-9678-e1ee0f139030.PNG)
