### PR TITLE
Change Action Button Markup

### DIFF
--- a/app/views/forever_style_guide/sections/visual_elements/_buttons.erb
+++ b/app/views/forever_style_guide/sections/visual_elements/_buttons.erb
@@ -77,19 +77,19 @@
 <div><label>Action Buttons - .btn-action</label></div>
 <button type="button" class="btn btn-default btn-action btn-lg">
   <%= fa_icon "play", class: "btn-action-icon" %>
-  <label class="btn-action-label">Action Button</label>
+  <span class="btn-action-label">Action Button</span>
 </button>
 <button type="button" class="btn btn-default btn-action">
   <%= fa_icon "play", class: "btn-action-icon" %>
-  <label class="btn-action-label">Action Button</label>
+  <span class="btn-action-label">Action Button</span>
 </button>
 <button type="button" class="btn btn-default btn-action btn-sm">
   <%= fa_icon "play", class: "btn-action-icon" %>
-  <label class="btn-action-label">Action Button</label>
+  <span class="btn-action-label">Action Button</span>
 </button>
 <button type="button" class="btn btn-default btn-action btn-xs">
   <%= fa_icon "play", class: "btn-action-icon" %>
-  <label class="btn-action-label">Action Button</label>
+  <span class="btn-action-label">Action Button</span>
 </button>
 <hr>
 <div><label>Button Groups -.btn-group</label></div>


### PR DESCRIPTION
Just updating the samples here. 

Pointed out by @csto that using the `<label>` element w/ in a button can cause issues depending on browser or submit action since the label expects an input element. For reference see the current ambassador search at store checkout which works when submitted by return but fails on click.
