### PR TITLE
Bug // Resize Triggers Hero Update When No Hero Image // 112150905

### DIFF
--- a/app/assets/javascripts/forever_style_guide/hero-blur.js
+++ b/app/assets/javascripts/forever_style_guide/hero-blur.js
@@ -416,6 +416,8 @@ $(function() {
 
 
 $(window).resize(function() {
+  if (!$(".hero-blur").length) return;
+
   var updateHeroModule = window.UpdateHeroModule;
 
   // Check window width has actually changed and it's not just iOS triggering a resize event on scroll

--- a/lib/forever_style_guide/version.rb
+++ b/lib/forever_style_guide/version.rb
@@ -1,3 +1,3 @@
 module ForeverStyleGuide
-  VERSION = "1.2.10"
+  VERSION = "1.2.11"
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/112150905

This is causing JS errors in the web app on resize.