### PR TITLE
Feature/improve checkbox styling/128502993

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    forever_style_guide (3.0.27)
+    forever_style_guide (3.0.25)
       bootstrap-sass
       font-awesome-rails
       jquery-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    forever_style_guide (3.0.25)
+    forever_style_guide (3.0.28)
       bootstrap-sass
       font-awesome-rails
       jquery-rails

--- a/app/assets/stylesheets/forever_style_guide/base/_forms.scss
+++ b/app/assets/stylesheets/forever_style_guide/base/_forms.scss
@@ -28,3 +28,10 @@
   border-radius: $border-radius-small;
   font-size: $font-size-small;
 }
+
+label {
+  color: $color-gray-600;
+  font-family: $font-face-regular;
+  font-size: $font-size-200;
+  font-weight: 400;
+}

--- a/app/assets/stylesheets/forever_style_guide/modules/_checkbox.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_checkbox.scss
@@ -1,69 +1,68 @@
-// Styling checkboxes and radio buttons by hiding the input and using pseudo-classes
-// This technique is a bit more tightly coupled to the markup than we'd prefer but it gives us a lot of cross-browser style control
-.checkbox.checkbox-branded,
-.checkbox-inline.checkbox-branded,
-.radio.radio-branded,
-.radio-inline.radio-branded {
-  input[type="checkbox"],
-  input[type="radio"] {
-    opacity: 0;
-    width: 0;
-    height: 0;
-  }
-  .checkbox-visual,
-  .radio-visual {
-    margin-right: 15px;
-    float: left;
+$checkbox_size: 20px;
 
-    &:before {
-      @extend %check-style;
-      background-color: color('gray-200');
-      color: color('gray-400');
-      font-family: fontawesome;
+@mixin checkbox($background-color, $border-color) {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: $checkbox_size;
+  height: $checkbox_size;
+  background-color: $background-color;
+  border: 2px solid $border-color;
+  border-radius: $border-radius-large;
+  @include transition(border-color 0.2s ease-in-out, background-color 0.2s ease-in-out);
+}
+
+.checkbox-branded {
+  position: relative;
+  font-size: $font-size-default;
+
+  &.checkbox { // using added specificity of .checkbox to override bootstrap
+    display: inline-block;
+ 
+    label {
+      padding-left: $checkbox_size + 10px;
     }
   }
-  input[type="checkbox"]:checked + .checkbox-visual:before,
-  input[type="radio"]:checked + .radio-visual:before {
-    color: color('white');
-    background-color: color('primary');
-  }
-  .checkbox-label,
-  .radio-label {
-    display: block;
-    padding-left: 0;
-    line-height: $btn-xs-size;
+
+  label {
+    cursor: pointer;
+    padding-left: $checkbox_size * 0.75;
+
+    @media (max-width: $screen-md-min) {
+      line-height: $font-size-default; // helps labels that wrap to two lines
+    }
+
+    &:before {
+      @include checkbox($color-white, $color-gray-400);
+      content: '';
+    }
+    &:after {
+      @include checkbox($color-white, $color-gray-400);
+      content: '\f00c';
+      font-family: fontawesome;
+      color: $color-white;
+      padding-left: 1px; // horizontal alignment of check w/ in box
+      line-height: 17px; // vertical alignment of check w/ in box
+      opacity: 0;
+    }
+    &:hover::after {
+      border-color: $color-gray-500;
+      opacity: 1;
+    }
+  } 
+
+  input[type=checkbox] {
+    visibility: hidden;
+
+    &:checked + label:after,
+    &:checked + .has-error label:after
+     {
+      @include checkbox($color-primary, color('primary-dark'));
+      opacity: 1;
+    }
   }
 }
-
-.checkbox-inline.checkbox-branded,
-.radio-inline.radio-branded {
-  padding-left: 0;
-
-  .checkbox-label,
-  .radio-label {
-    display: inline-block;
-    margin-right: 25px;
-  }
-}
-
-.checkbox.checkbox-branded, 
-.checkbox-inline.checkbox-branded {
-  .checkbox-visual:before {
-    content: "\f00c";
-    border-radius: $border-radius-default;
-  }
-  input[type="checkbox"]:checked + .checkbox-visual:before {
-    background-color: color('primary');
-  }
-}
-.radio.radio-branded,
-.radio-inline.radio-branded {
-  .radio-visual:before {
-    content: "\f111";
-    padding-top: 1px; //shim for text alignment
-    @include circle($btn-xs-size, color('gray-200'));
-  }
-  input[type="radio"]:checked + .radio-visual:before {
-    background-color: color('secondary');
-  }
+.checkbox-branded-inline {
+  float: left;
+  margin-right: $checkbox_size * 1.5;
 }

--- a/app/assets/stylesheets/forever_style_guide/modules/_checkbox.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_checkbox.scss
@@ -20,7 +20,7 @@ $checkbox_size: 20px;
     display: inline-block;
  
     label {
-      padding-left: $checkbox_size + 10px;
+      padding-left: $checkbox_size * 1.5;
     }
   }
 

--- a/app/views/forever_style_guide/sections/visual_elements/_forms.erb
+++ b/app/views/forever_style_guide/sections/visual_elements/_forms.erb
@@ -13,58 +13,61 @@
     <input type="file" id="exampleInputFile">
     <p class="help-block">Example block-level help text here.</p>
   </div>
-  <div class="checkbox checkbox-branded l-section">
-    <label for="agree" class="checkbox-label">
-      <input type="checkbox" name="agree" id="agree">
-      <span class="checkbox-visual"></span>
-      Click here if you agree to the Terms &amp; Conditions
-    </label>
+
+  <h3 class="color-gray-500 l-section-far">Checkboxes</h2>
+  <p class="gray-600">Just add the checkbox-branded class to your form-group div got get branded styling via label:before and label:after.</p>
+  <div class="form-group form-group-lg checkbox checkbox-branded l-section-close">
+    <%= check_box_tag "terms_of_service" %>
+    <%= label_tag "terms_of_service" do %>
+      I have read and agree to the <a href= "/tos">Terms of Service</a> and <a href= "/tos">Privacy Policy</a>
+    <% end %>
   </div>
-  <div class="form-group  l-section-close">
-    <div class="checkbox checkbox-inline checkbox-branded">
-      <label for="inline1" class="checkbox-label">
-        <input type="checkbox" name="inline1" id="inline1" check>
-        <span class="checkbox-visual"></span>
-        Inline option
-      </label>
-      <label for="inline2" class="checkbox-label">
-        <input type="checkbox" name="inline2" id="inline2">
-        <span class="checkbox-visual"></span>
-        Inline alternate option
-      </label>
+
+  <div class="clearfix">
+    <div class="form-group form-group-lg checkbox-branded checkbox-branded-inline">
+      <%= check_box_tag 'option1' %>
+      <%= label_tag  'option1', 'Upsell 1 (+ $3.99)' %>
+    </div>
+
+    <div class="form-group form-group-lg checkbox-branded checkbox-branded-inline">
+      <%= check_box_tag 'option2' %>
+      <%= label_tag 'option2', 'Upsell 2 (+ $3.99)' %>
     </div>
   </div>
+
+  <h3 class="color-gray-500 l-section">Radios (Coming Soon!)</h2>
   <div class="radio radio-branded l-section">
+    <p class="gray-600">Just add the radio-branded class to your form-group div got get branded styling via label:before and label:after.</p>
     <label class="radio-label">
       <input type="radio" name="optionsRadios" id="optionsRadios1" value="option1" checked>
-      <span class="radio-visual"></span>
-      Option one is this and that&mdash;be sure to include why it's great
+      Option one is this and that
     </label>
     <label class="radio-label radio-branded l-section-close">
       <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
-      <span class="radio-visual"></span>
-      Option two can be something else and selecting it will deselect option one
+      Option two can be something else
     </label>
   </div>
+
   <div class="form-group l-section-close">
-  <div class="radio radio-inline radio-branded">
-    <label class="radio-label">
-      <input type="radio" name="optionsRadios" id="optionsRadios1" value="option1" checked>
-      <span class="radio-visual"></span>
-      Option One Inline
-    </label>
-    <label class="radio-label radio-branded">
-      <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
-      <span class="radio-visual"></span>
-      Option Two Inline
-    </label>
-    <label class="radio-label radio-branded">
-      <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
-      <span class="radio-visual"></span>
-      Option Three Inline
-    </label>
+    <div class="radio radio-inline radio-branded">
+      <label class="radio-label">
+        <input type="radio" name="optionsRadios" id="optionsRadios1" value="option1" checked>
+        <span class="radio-visual"></span>
+        Option One Inline
+      </label>
+      <label class="radio-label radio-branded">
+        <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
+        <span class="radio-visual"></span>
+        Option Two Inline
+      </label>
+      <label class="radio-label radio-branded">
+        <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
+        <span class="radio-visual"></span>
+        Option Three Inline
+      </label>
+    </div>
   </div>
-  </div>
+
   <div class="form-group l-section">
     <div class="select">
       <select class="select-field form-control">
@@ -79,6 +82,7 @@
   <button type="submit" class="btn btn-primary">Submit</button>
 </form>
 <hr>
+
 <label>Input Sizing</label>
 <form>
   <div class="form-group">

--- a/forever_style_guide.gemspec
+++ b/forever_style_guide.gemspec
@@ -14,8 +14,16 @@ Gem::Specification.new do |s|
   s.description = "Install this as a gem in your Forever app and it will expose style guide through /style-guide route"
   s.license     = "MIT"
 
-  s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
-  s.test_files = Dir["test/**/*"]
+  s.files = Dir[
+    "{config,db,lib}/**/*",
+    "{app/assets/fonts}/**/*",
+    "{app/assets/images/forever_style_guide}/**/*",
+    "{app/assets/javascripts/forever_style_guide}/**/*",
+    "{app/assets/stylesheets/forever_style_guide}/**/*",
+    "{app/helpers/forever_style_guide}/**/*",
+    "{app/views/forever_style_guide/sections/components/navigation}/**/*",
+    "{app/views/forever_style_guide/sections/components/footer}/**/*"
+    ]
 
   s.add_dependency "rails", "~> 4.2.0"
   s.add_dependency "style-guide"

--- a/lib/forever_style_guide/version.rb
+++ b/lib/forever_style_guide/version.rb
@@ -1,3 +1,3 @@
 module ForeverStyleGuide
-  VERSION = "3.0.25"
+  VERSION = "3.0.28"
 end

--- a/lib/forever_style_guide/version.rb
+++ b/lib/forever_style_guide/version.rb
@@ -1,3 +1,3 @@
 module ForeverStyleGuide
-  VERSION = "3.0.27"
+  VERSION = "3.0.25"
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/128502993

updates checkbox styling so we can use rails form helpers. radio button styling isn't included here due to time, but I don't think there are any custom styles being used on them in the store currently, so they shouldn't be affected by this


<img width="579" alt="screen shot 2016-09-15 at 10 18 11 am" src="https://cloud.githubusercontent.com/assets/1926679/18553249/c044c270-7b2d-11e6-9bba-5a3854a53fa5.png">