### PR TITLE
Allow ambassadors to specifty full URL's.

### DIFF
--- a/app/helpers/forever_style_guide/application_helper.rb
+++ b/app/helpers/forever_style_guide/application_helper.rb
@@ -398,6 +398,16 @@ module ForeverStyleGuide
       "https://forever1.zendesk.com/hc/en-us/articles/223595308-Using-Albums-and-Tags-Video-"
     end
 
+    def absolute_url(url_str)
+      return  unless url_str.present?
+
+      url_str = url_str.strip
+
+      return url_str if url_str =~ /https?\:/i
+
+      "http://" + url_str
+    end
+
     # Path helpers for style guide dummy app
     def style_guide_path
       Rails.application.routes.named_routes[:forever_style_guide].path.spec.to_s

--- a/app/helpers/forever_style_guide/application_helper.rb
+++ b/app/helpers/forever_style_guide/application_helper.rb
@@ -32,6 +32,16 @@ module ForeverStyleGuide
       url = URI.decode(url.to_s)
     end
 
+    def absolute_url(url_str)
+      return  unless url_str.present?
+
+      url_str = url_str.strip
+
+      return url_str if url_str =~ /https?\:/i
+
+      "http://" + url_str
+    end
+
     def has_item_in_cart?
       defined?(current_order) && current_order.product_count > 0
     end
@@ -396,16 +406,6 @@ module ForeverStyleGuide
 
     def zendesk_tags_video_url
       "https://forever1.zendesk.com/hc/en-us/articles/223595308-Using-Albums-and-Tags-Video-"
-    end
-
-    def absolute_url(url_str)
-      return  unless url_str.present?
-
-      url_str = url_str.strip
-
-      return url_str if url_str =~ /https?\:/i
-
-      "http://" + url_str
     end
 
     # Path helpers for style guide dummy app

--- a/app/views/forever_style_guide/sections/components/navigation/_nav_ambassador_dropdown.erb
+++ b/app/views/forever_style_guide/sections/components/navigation/_nav_ambassador_dropdown.erb
@@ -56,33 +56,33 @@
                 </div>
               <% end %>
 
-              <% if current_ambassador.website %>
+              <% if current_ambassador.website.present? %>
                 <div class="col-grid-float-6">
-                  <%= link_to '//' + current_ambassador.website, title: current_ambassador.website, class: 'btn btn-default btn-link btn-action dropdown-ambassador-contact_btn', target: '_blank' do %>
+                  <%= link_to absolute_url(current_ambassador.website), title: current_ambassador.website, class: 'btn btn-default btn-link btn-action dropdown-ambassador-contact_btn', target: '_blank' do %>
                     <i class="fa fa-fw fa-link btn-action-icon"></i><span class="btn-action-label">My Website</span>
                   <% end %>
                 </div>
               <% end %>
 
-              <% if current_ambassador.facebook_url %>
+              <% if current_ambassador.facebook_url.present? %>
                 <div class="col-grid-float-6">
-                  <%= link_to '//' + current_ambassador.facebook_url, title: current_ambassador.facebook_url, class: 'btn btn-default btn-link btn-action dropdown-ambassador-contact_btn', target: '_blank' do %>
+                  <%= link_to absolute_url(current_ambassador.facebook_url), title: current_ambassador.facebook_url, class: 'btn btn-default btn-link btn-action dropdown-ambassador-contact_btn', target: '_blank' do %>
                     <i class="fa fa-fw fa-facebook btn-action-icon"></i><span class="btn-action-label">My Facebook Page</span>
                   <% end %>
                 </div>
               <% end %>
 
-              <% if current_ambassador.twitter_handle %>
+              <% if current_ambassador.twitter_handle.present? %>
                 <div class="col-grid-float-6">
-                  <%= link_to '//' + current_ambassador.twitter_handle, title: current_ambassador.twitter_handle, class: 'btn btn-default btn-link btn-action dropdown-ambassador-contact_btn', target: '_blank' do %>
+                  <%= link_to absolute_url(current_ambassador.twitter_handle), title: current_ambassador.twitter_handle, class: 'btn btn-default btn-link btn-action dropdown-ambassador-contact_btn', target: '_blank' do %>
                     <i class="fa fa-fw fa-twitter btn-action-icon"></i><span class="btn-action-label">Follow me on Twitter</span>
                   <% end %>
                 </div>
               <% end %>
 
-              <% if current_ambassador.instagram_url %>
+              <% if current_ambassador.instagram_url.present? %>
                 <div class="col-grid-float-6">
-                  <%= link_to '//' + current_ambassador.instagram_url, title: current_ambassador.instagram_url, class: 'btn btn-default btn-link btn-action dropdown-ambassador-contact_btn', target: '_blank' do %>
+                  <%= link_to absolute_url(current_ambassador.instagram_url), title: current_ambassador.instagram_url, class: 'btn btn-default btn-link btn-action dropdown-ambassador-contact_btn', target: '_blank' do %>
                     <i class="fa fa-fw fa-instagram btn-action-icon"></i><span class="btn-action-label">Follow me on Instagram</span>
                   <% end %>
                 </div>

--- a/app/views/forever_style_guide/sections/components/navigation/_nav_ambassador_dropdown.erb
+++ b/app/views/forever_style_guide/sections/components/navigation/_nav_ambassador_dropdown.erb
@@ -58,7 +58,7 @@
 
               <% if current_ambassador.website.present? %>
                 <div class="col-grid-float-6">
-                  <%= link_to absolute_url(current_ambassador.website), title: current_ambassador.website, class: 'btn btn-default btn-link btn-action dropdown-ambassador-contact_btn', target: '_blank' do %>
+                  <%= link_to absolute_url(current_ambassador.website), title: absolute_url(current_ambassador.website), class: 'btn btn-default btn-link btn-action dropdown-ambassador-contact_btn', target: '_blank' do %>
                     <i class="fa fa-fw fa-link btn-action-icon"></i><span class="btn-action-label">My Website</span>
                   <% end %>
                 </div>
@@ -66,7 +66,7 @@
 
               <% if current_ambassador.facebook_url.present? %>
                 <div class="col-grid-float-6">
-                  <%= link_to absolute_url(current_ambassador.facebook_url), title: current_ambassador.facebook_url, class: 'btn btn-default btn-link btn-action dropdown-ambassador-contact_btn', target: '_blank' do %>
+                  <%= link_to absolute_url(current_ambassador.facebook_url), title: absolute_url(current_ambassador.facebook_url), class: 'btn btn-default btn-link btn-action dropdown-ambassador-contact_btn', target: '_blank' do %>
                     <i class="fa fa-fw fa-facebook btn-action-icon"></i><span class="btn-action-label">My Facebook Page</span>
                   <% end %>
                 </div>
@@ -74,7 +74,7 @@
 
               <% if current_ambassador.twitter_handle.present? %>
                 <div class="col-grid-float-6">
-                  <%= link_to absolute_url(current_ambassador.twitter_handle), title: current_ambassador.twitter_handle, class: 'btn btn-default btn-link btn-action dropdown-ambassador-contact_btn', target: '_blank' do %>
+                  <%= link_to absolute_url(current_ambassador.twitter_handle), title: absolute_url(current_ambassador.twitter_handle), class: 'btn btn-default btn-link btn-action dropdown-ambassador-contact_btn', target: '_blank' do %>
                     <i class="fa fa-fw fa-twitter btn-action-icon"></i><span class="btn-action-label">Follow me on Twitter</span>
                   <% end %>
                 </div>
@@ -82,7 +82,7 @@
 
               <% if current_ambassador.instagram_url.present? %>
                 <div class="col-grid-float-6">
-                  <%= link_to absolute_url(current_ambassador.instagram_url), title: current_ambassador.instagram_url, class: 'btn btn-default btn-link btn-action dropdown-ambassador-contact_btn', target: '_blank' do %>
+                  <%= link_to absolute_url(current_ambassador.instagram_url), title: absolute_url(current_ambassador.instagram_url), class: 'btn btn-default btn-link btn-action dropdown-ambassador-contact_btn', target: '_blank' do %>
                     <i class="fa fa-fw fa-instagram btn-action-icon"></i><span class="btn-action-label">Follow me on Instagram</span>
                   <% end %>
                 </div>

--- a/lib/forever_style_guide/version.rb
+++ b/lib/forever_style_guide/version.rb
@@ -1,3 +1,3 @@
 module ForeverStyleGuide
-  VERSION = "3.0.32"
+  VERSION = "3.0.33"
 end


### PR DESCRIPTION
Allows URL's in ambassador records to include http: and https: protocols.

Also handles partial URL's that begin with the host name.

When testing for presence of a URL in an amabassador record, use present? to ignore blank values.