### PR TITLE
Feature/account popover links/134035493

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    forever_style_guide (3.0.37)
+    forever_style_guide (3.0.38)
       bootstrap-sass
       font-awesome-rails
       jquery-rails

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav-dropdowns-account.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav-dropdowns-account.scss
@@ -19,8 +19,8 @@
   overflow: hidden;
 
   @media (min-width: $grid-float-breakpoint) {
-    padding-top: 5px;
-    padding-bottom: 5px;
+    padding-top: 0;
+    padding-bottom: 10px;
   }
 }
 .dropdown-menu-account-divider {
@@ -31,6 +31,10 @@
   @media (max-width: $grid-float-breakpoint-max) {
     border-color: color('gray-600');
   }
+}
+.dropdown-menu-account-divider-thin {
+  margin-top: 0;
+  border-color: color('gray-600');
 }
 .dropdown-menu-account-user {
   overflow: hidden;
@@ -52,7 +56,6 @@
   }
 }
 .dropdown-menu-account-storage {
-  @media (max-width: $grid-float-breakpoint-max) {
-    font-size: $font-size-default;
-  }
+  margin-bottom: 0;
+  font-size: $font-size-200;
 }

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav-dropdowns-account.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav-dropdowns-account.scss
@@ -1,6 +1,7 @@
 .dropdown-menu-account {
   width: 100%;
   right: 0;
+  padding-top: 15px;
   border-bottom-right-radius: $border-radius-large;
   border-bottom-left-radius: $border-radius-large;
 
@@ -20,7 +21,7 @@
 
   @media (min-width: $grid-float-breakpoint) {
     padding-top: 0;
-    padding-bottom: 10px;
+    padding-bottom: $padding-small-vertical;
   }
 }
 .dropdown-menu-account-divider {

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav-dropdowns.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav-dropdowns.scss
@@ -129,7 +129,7 @@ a.dropdown-menu-nav-link {
       margin-top: 15px;
     }
   }
-  &.dropdown-menu-nav-link-small {
+  &.dropdown-menu-nav-link-sm {
     font-size: $font-size-default;
   }
   .fa {

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav-dropdowns.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav-dropdowns.scss
@@ -129,6 +129,9 @@ a.dropdown-menu-nav-link {
       margin-top: 15px;
     }
   }
+  &.dropdown-menu-nav-link-small {
+    font-size: $font-size-default;
+  }
   .fa {
     margin-right: 10px;
   }

--- a/app/helpers/forever_style_guide/application_helper.rb
+++ b/app/helpers/forever_style_guide/application_helper.rb
@@ -126,8 +126,17 @@ module ForeverStyleGuide
       web_app_url('/')
     end
 
+    # User settings links (store and web app)
     def user_settings_url
       web_app_url('/#/settings')
+    end
+
+    def user_order_history_url
+      www_url('/settings/orders')
+    end
+
+    def user_downloads_url
+      www_url('/settings/downloads')
     end
 
     def ambassador_settings_url

--- a/app/views/forever_style_guide/sections/components/navigation/_nav_account_dropdown_menu.erb
+++ b/app/views/forever_style_guide/sections/components/navigation/_nav_account_dropdown_menu.erb
@@ -16,8 +16,6 @@
           </div>
         </li>
 
-        <li class="dropdown-menu-account-divider"></li>
-
         <% if current_user.superadmin? %>
           <li class="dropdown-menu-account-item">
             <%= link_to store_admin_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-no_margin', title: 'Administer The Forever Store' do %>
@@ -33,10 +31,10 @@
         <% end %>
 
         <li class="dropdown-menu-account-item <%= 'hide' if current_user.superadmin? %>">
-          <p class="color-gray-300">
+          <p class="dropdown-menu-account-storage color-gray-300">
 
-            <span class="dropdown-menu-account-storage"><%= storage_ratio_percent %> of <%= capacity_readable %></span>
-            <%= link_to "Upgrade", upgrade_url, class: 'small', title: "Upgrade your Forever Guaranteed Permanent Storage" %>
+            <%= storage_ratio_percent %> of <%= capacity_readable %>
+            <%= link_to "Upgrade", upgrade_url, title: "Upgrade your Forever Guaranteed Permanent Storage" %>
           </p>
 
           <div class="progress progress-thin color_block-gray-400">
@@ -44,27 +42,44 @@
           </div>
         </li>
 
-        <li class="dropdown-menu-account-divider"></li>
-
-        <li class="dropdown-menu-account-item">
-          <%= link_to user_settings_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-no_margin', title: 'View User Settings' do %>
-            <i class='fa fa-cog fa-fw'></i>Settings
-          <% end %>
-        </li>
-
         <% if current_user.linked_ambassador.try(:active?) %>
           <li class="dropdown-menu-account-item">
-            <%= link_to back_office_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-no_margin', title: 'Ambassador Back Office Reports' do %>
+            <%= link_to back_office_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-small dropdown-menu-nav-link-no_margin', title: 'Ambassador Back Office Reports' do %>
               <i class='fa fa-suitcase fa-fw'></i>My Back Office
             <% end %>
           </li>
+          <li class="dropdown-menu-account-divider dropdown-menu-account-divider-thin hidden-xs hidden-sm"></li>
         <% end %>
 
-        <li class="dropdown-menu-account-divider hidden-xs hidden-sm"></li>
+        <li class="dropdown-menu-account-item">
+          <%= link_to user_settings_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-small dropdown-menu-nav-link-no_margin', title: 'View User Settings' do %>
+            <i class='fa fa-cog fa-fw'></i>Account Settings
+          <% end %>
+        </li>
+
+        <li class="dropdown-menu-account-item">
+          <%= link_to user_order_history_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-small dropdown-menu-nav-link-no_margin', title: 'View Order History' do %>
+            <i class='fa fa-credit-card fa-fw'></i>Order History
+          <% end %>
+        </li>
+
+        <li class="dropdown-menu-account-item">
+          <%= link_to user_downloads_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-small dropdown-menu-nav-link-no_margin', title: 'View Downloads' do %>
+            <i class='fa fa-cloud-download fa-fw'></i>Downloads
+          <% end %>
+        </li>
+
+        <li class="dropdown-menu-account-item">
+          <%= link_to projects_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-small dropdown-menu-nav-link-no_margin', title: 'View Downloads' do %>
+            <i class='fa fa-paint-brush fa-fw'></i>Print Projects
+          <% end %>
+        </li>
+
+        <li class="dropdown-menu-account-divider dropdown-menu-account-divider-thin hidden-xs hidden-sm"></li>
 
         <li class="dropdown-menu-account-item">
 
-          <%= link_to current_admin ? stop_impersonating_url : log_out_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-no_margin', title: 'Log Out of Forever' do %>
+          <%= link_to current_admin ? stop_impersonating_url : log_out_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-small dropdown-menu-nav-link-no_margin', title: 'Log Out of Forever' do %>
             <i class='fa fa-share fa-fw'></i>Log Out
           <% end %>
         </li>

--- a/app/views/forever_style_guide/sections/components/navigation/_nav_account_dropdown_menu.erb
+++ b/app/views/forever_style_guide/sections/components/navigation/_nav_account_dropdown_menu.erb
@@ -1,6 +1,6 @@
 <div class='container-fluid'>
   <div class='row'>
-    <div class='col-xs-12 l-padded-thin'>
+    <div class='col-xs-12'>
 
       <ul class="list-unstyled">
         <li class="dropdown-menu-account-item">
@@ -18,16 +18,18 @@
 
         <% if current_user.superadmin? %>
           <li class="dropdown-menu-account-item">
-            <%= link_to store_admin_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-no_margin', title: 'Administer The Forever Store' do %>
+            <%= link_to store_admin_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-sm dropdown-menu-nav-link-no_margin', title: 'Administer The Forever Store' do %>
               <i class='fa fa-shopping-basket fa-fw'></i>Store Admin
             <% end %>
           </li>
 
           <li class="dropdown-menu-account-item">
-            <%= link_to web_app_admin_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-no_margin', title: 'Administer The Forever Web App' do %>
+            <%= link_to web_app_admin_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-sm dropdown-menu-nav-link-no_margin', title: 'Administer The Forever Web App' do %>
               <i class='fa fa-magic fa-fw'></i>Web App Admin
             <% end %>
           </li>
+
+          <li class="dropdown-menu-account-divider dropdown-menu-account-divider-thin hidden-xs hidden-sm"></li>
         <% end %>
 
         <li class="dropdown-menu-account-item <%= 'hide' if current_user.superadmin? %>">
@@ -44,7 +46,7 @@
 
         <% if current_user.linked_ambassador.try(:active?) %>
           <li class="dropdown-menu-account-item">
-            <%= link_to back_office_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-small dropdown-menu-nav-link-no_margin', title: 'Ambassador Back Office Reports' do %>
+            <%= link_to back_office_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-sm dropdown-menu-nav-link-no_margin', title: 'Ambassador Back Office Reports' do %>
               <i class='fa fa-suitcase fa-fw'></i>My Back Office
             <% end %>
           </li>
@@ -52,25 +54,25 @@
         <% end %>
 
         <li class="dropdown-menu-account-item">
-          <%= link_to user_settings_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-small dropdown-menu-nav-link-no_margin', title: 'View User Settings' do %>
+          <%= link_to user_settings_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-sm dropdown-menu-nav-link-no_margin', title: 'View User Settings' do %>
             <i class='fa fa-cog fa-fw'></i>Account Settings
           <% end %>
         </li>
 
         <li class="dropdown-menu-account-item">
-          <%= link_to user_order_history_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-small dropdown-menu-nav-link-no_margin', title: 'View Order History' do %>
+          <%= link_to user_order_history_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-sm dropdown-menu-nav-link-no_margin', title: 'View Order History' do %>
             <i class='fa fa-credit-card fa-fw'></i>Order History
           <% end %>
         </li>
 
         <li class="dropdown-menu-account-item">
-          <%= link_to user_downloads_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-small dropdown-menu-nav-link-no_margin', title: 'View Downloads' do %>
+          <%= link_to user_downloads_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-sm dropdown-menu-nav-link-no_margin', title: 'View Downloads' do %>
             <i class='fa fa-cloud-download fa-fw'></i>Downloads
           <% end %>
         </li>
 
         <li class="dropdown-menu-account-item">
-          <%= link_to projects_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-small dropdown-menu-nav-link-no_margin', title: 'View Downloads' do %>
+          <%= link_to projects_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-sm dropdown-menu-nav-link-no_margin', title: 'View Downloads' do %>
             <i class='fa fa-paint-brush fa-fw'></i>Print Projects
           <% end %>
         </li>
@@ -79,7 +81,7 @@
 
         <li class="dropdown-menu-account-item">
 
-          <%= link_to current_admin ? stop_impersonating_url : log_out_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-small dropdown-menu-nav-link-no_margin', title: 'Log Out of Forever' do %>
+          <%= link_to current_admin ? stop_impersonating_url : log_out_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-sm dropdown-menu-nav-link-no_margin', title: 'Log Out of Forever' do %>
             <i class='fa fa-share fa-fw'></i>Log Out
           <% end %>
         </li>

--- a/app/views/forever_style_guide/sections/components/navigation/_nav_account_dropdown_menu.erb
+++ b/app/views/forever_style_guide/sections/components/navigation/_nav_account_dropdown_menu.erb
@@ -72,7 +72,7 @@
         </li>
 
         <li class="dropdown-menu-account-item">
-          <%= link_to projects_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-sm dropdown-menu-nav-link-no_margin', title: 'View Downloads' do %>
+          <%= link_to projects_url, class: 'dropdown-menu-nav-link dropdown-menu-nav-link-sm dropdown-menu-nav-link-no_margin', title: 'View Print Projects' do %>
             <i class='fa fa-paint-brush fa-fw'></i>Print Projects
           <% end %>
         </li>

--- a/lib/forever_style_guide/version.rb
+++ b/lib/forever_style_guide/version.rb
@@ -1,3 +1,3 @@
 module ForeverStyleGuide
-  VERSION = "3.0.37"
+  VERSION = "3.0.38"
 end


### PR DESCRIPTION
Updates user account drop down in primary nav: https://www.pivotaltracker.com/story/show/134035493

This is on hold b/c we were too aggressive w/ an earlier change (needs the migration here: https://github.com/forever-inc/a-new-hope/pull/352)


## To Test
* change store Gemfile to look at local styleguide 
``` gem 'forever_style_guide', '3.0.38', path: '../forever-style-guide```
* COMMENT OUT / temporarily remove line 37 in nav_ambassador_dropdown.erb (https://github.com/forever-inc/forever-style-guide/blob/feature/account-popover-links/134035493/app/views/forever_style_guide/sections/components/navigation/_nav_ambassador_dropdown.erb#L37)
* Bundle and restart your store. 


# User
![user](https://cloud.githubusercontent.com/assets/3814998/20713056/cb5aabbc-b614-11e6-8f2a-0965d9be9f6a.png)

# Ambassador
![ambassador](https://cloud.githubusercontent.com/assets/3814998/20713063/d02f56b0-b614-11e6-845b-6c9d514b5b2e.png)

# Admin
![admin](https://cloud.githubusercontent.com/assets/3814998/20713069/d65962e2-b614-11e6-9fc4-27ed444130f7.png)

# Admin + Ambassador

![admin ambassador](https://cloud.githubusercontent.com/assets/3814998/20713073/dcc432ce-b614-11e6-88c9-0acbd20f9f48.png)




