### PR TITLE
Dev to Master - 3.2.6 - Slant Effect and footer trademark updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    forever_style_guide (3.2.5)
+    forever_style_guide (3.2.6)
       bootstrap-sass
       font-awesome-rails
       jquery-rails

--- a/app/assets/stylesheets/forever_style_guide/globals/_effects.scss
+++ b/app/assets/stylesheets/forever_style_guide/globals/_effects.scss
@@ -161,3 +161,43 @@ $color-card-bg: color('white');
     }
   }
 }
+
+// add this class to any section to add a slant effect to the top of that element
+// custom positioning required for resize of end spectrums -> xxl and sm screens
+$slant-position-top: -40px;
+$slant-position-top-sm: -15px;
+$slant-position-top-xxl: -80px;
+
+$slant-height: 95px;
+$slant-height-sm: 65px;
+$slant-height-xxl: 220px;
+
+$slant-angle-left: -182deg;
+$slant-angle-right: 182deg;
+
+.slant::before {
+  content: "";
+  display: block;
+  position: relative;
+  top: $slant-position-top;
+  height: $slant-height;
+  background-color: inherit;
+
+  @media (min-width: $screen-xxl) {
+    top: $slant-position-top-xxl;
+    height: $slant-height-xxl;
+  }
+
+  @media (max-width: $screen-sm) {
+    top: $slant-position-top-sm;
+    height: $slant-height-sm;
+  }
+}
+
+.slant-left::before {
+  @include transform(skewY($slant-angle-left));
+}
+
+.slant-right::before {
+  @include transform(skewY($slant-angle-right));
+}

--- a/app/views/forever_style_guide/sections/components/footer/_footer.erb
+++ b/app/views/forever_style_guide/sections/components/footer/_footer.erb
@@ -1,20 +1,23 @@
 <footer class="footer color_block-gray-700">
   <div class="container-fluid color_block-services-dark">
-    <h4 class="color-white text-center footer-header">Collect, curate, and celebrate your memories now and for generations.</h4>
+    <h4 class="color-white text-center footer-header">Collect, curate, and celebrate your memories now and for generations&trade;</h4>
   </div>
 
   <div class="container footer-main_block">
     <div class="row">
 
       <div class="col-md-6 col-md-push-3 col-xs-12">
-        <h4 class="color-gray-300 footer-title">Forever&trade; Products</h4>
+        <h4 class="color-gray-300 footer-title">FOREVER&trade; Products</h4>
         <hr class="footer-divider" />
         <div class="row">
           <div class="col-xs-6">
             <ul class="list-unstyled">
-              <li><%= link_to trademark("Forever Storage"), storage_url, class: "footer-link", title: "Guaranteed Permanent Storage for Photos & Documents" %></li>
-              <li><%= link_to trademark("Forever Artisan"), artisan_url, class: "footer-link", title: "Forever Artisan 5 Digital Scrapbooking Software" %></li>
-              <li><%= link_to trademark("Forever Historian"), historian_url, class: "footer-link", title: "Photo Management Software for Windows" %></li>
+
+              <!-- TODO use trademark helper when it appropriately handles upcasing -->
+              <li><%= link_to "FOREVER Storage®", storage_url, class: "footer-link", title: "Guaranteed Permanent Storage for Photos & Documents" %></li>
+              <li><%= link_to "FOREVER Artisan®", artisan_url, class: "footer-link", title: "Forever Artisan 5 Digital Scrapbooking Software" %></li>
+              <li><%= link_to "FOREVER Historian™", historian_url, class: "footer-link", title: "Photo Management Software for Windows" %></li>
+
             </ul>
           </div>
           <div class="col-xs-6">
@@ -35,7 +38,7 @@
         <h4 class="color-gray-300 footer-title">Support</h4>
         <hr class="footer-divider" />
         <ul class="list-unstyled">
-          <li><%= link_to "Visit Forever Help Center", help_center_url, class: "footer-link", title: "Visit the Forever Help Center", target: '_blank' %></li>
+          <li><%= link_to "Visit FOREVER Help Center", help_center_url, class: "footer-link", title: "Visit the FOREVER Help Center", target: '_blank' %></li>
           <li><%= mail_to "support@forever.com", "support@forever.com", class: "footer-link", title: "Email us at support@forever.com" %></li>
           <li><%= link_to "1-888-FOREVER (1-888-367-3837)", "tel:1-888-367-3837", class: "footer-link", title: "Call us at 1-888-367-3837" %></li>
         </ul>
@@ -45,30 +48,30 @@
          <h4 class="color-gray-300 footer-title">Stay Connected</h4>
         <hr class="footer-divider" />
         <div class="footer-social_icons">
-          <%= link_to (fa_stacked_icon "facebook feature_bullet-icon", base: "circle", class: "fa-feature_bullet color-gray-600"), facebook_url, title: "Follow Forever on Facebook", target: '_blank' %>
-          <%= link_to (fa_stacked_icon "twitter feature_bullet-icon", base: "circle", class: "fa-feature_bullet color-gray-600"), twitter_url, title: "Follow Forever on Twitter", target: '_blank' %>
-          <%= link_to (fa_stacked_icon "instagram feature_bullet-icon", base: "circle", class: "fa-feature_bullet color-gray-600"), instagram_url, title: "Follow Forever on Instagram", target: '_blank' %>
-          <%= link_to (fa_stacked_icon "youtube feature_bullet-icon", base: "circle", class: "fa-feature_bullet color-gray-600"), youtube_url, title: "Follow Forever on YouTube", target: '_blank' %>
-          <%= link_to (fa_stacked_icon "pinterest feature_bullet-icon", base: "circle", class: "fa-feature_bullet color-gray-600"), pinterest_url, title: "Follow Forever on Pinterest", target: '_blank' %>
+          <%= link_to (fa_stacked_icon "facebook feature_bullet-icon", base: "circle", class: "fa-feature_bullet color-gray-600"), facebook_url, title: "Follow FOREVER on Facebook", target: '_blank' %>
+          <%= link_to (fa_stacked_icon "twitter feature_bullet-icon", base: "circle", class: "fa-feature_bullet color-gray-600"), twitter_url, title: "Follow FOREVER on Twitter", target: '_blank' %>
+          <%= link_to (fa_stacked_icon "instagram feature_bullet-icon", base: "circle", class: "fa-feature_bullet color-gray-600"), instagram_url, title: "Follow FOREVER on Instagram", target: '_blank' %>
+          <%= link_to (fa_stacked_icon "youtube feature_bullet-icon", base: "circle", class: "fa-feature_bullet color-gray-600"), youtube_url, title: "Follow FOREVER on YouTube", target: '_blank' %>
+          <%= link_to (fa_stacked_icon "pinterest feature_bullet-icon", base: "circle", class: "fa-feature_bullet color-gray-600"), pinterest_url, title: "Follow FOREVER on Pinterest", target: '_blank' %>
         </div>
       </div>
     </div>
 
     <div class="row l-section-close">
       <div class="col-xs-12 col-sm-6 col-md-4">
-        <p class="footer-link footer-link-dark footer-copyright">&copy; <%= Time.now.year %> Forever, Inc</p>
+        <p class="footer-link footer-link-dark footer-copyright">&copy; <%= Time.now.year %> FOREVER, Inc</p>
       </div>
       
       <div class="col-xs-12 col-sm-6 col-md-4 col-md-push-4">
         <p class="small color-gray-400 footer-policy_links">
-          <%= link_to "Careers", careers_url, title: "Join the Forever Team", class: "footer-link footer-link-dark", target: '_blank' %> |
-          <%= link_to "Privacy Policy", privacy_url, class: "footer-link footer-link-dark", title: "Forever Privacy Policy" %> |
-          <%= link_to "Terms of Service", tos_url, class: "footer-link footer-link-dark", title: "Forever Terms of Service" %>
+          <%= link_to "Careers", careers_url, title: "Join the FOREVER Team", class: "footer-link footer-link-dark", target: '_blank' %> |
+          <%= link_to "Privacy Policy", privacy_url, class: "footer-link footer-link-dark", title: "FOREVER Privacy Policy" %> |
+          <%= link_to "Terms of Service", tos_url, class: "footer-link footer-link-dark", title: "FOREVER Terms of Service" %>
         </p>
       </div>
 
       <div class="col-xs-12 col-md-4 col-md-pull-4">
-        <small class="color-gray-500 footer-location">1 PPG Place 20th Floor • Pittsburgh, PA 15222 USA</small>
+        <small class="color-gray-500 footer-location">One PPG Place 20th Floor • Pittsburgh, PA 15222 USA</small>
       </div>
     </div>
   </div>

--- a/lib/forever_style_guide/version.rb
+++ b/lib/forever_style_guide/version.rb
@@ -1,3 +1,3 @@
 module ForeverStyleGuide
-  VERSION = "3.2.5"
+  VERSION = "3.2.6"
 end


### PR DESCRIPTION
* expanding button colors to include not just core colors but also brand colors and other mixins

* create an inveres button that is not limited to background color white and would rather inherit background color

* added slants as effect

* revert additional button class

* Update Gemfile.lock

* removed accidentally committed gem files

* version bump from 3.2.5 to 3.2.6

* revert button update to only include core colors

* fix indentation

* clarified comment for slant usage

* refactor of slant effect, included transform mixin for relevant support to skew

* declaration order and comments

* responsive refactor for xxl and sm screens

* tweak responsive numbers in testing

* nav updates per trademark review

* whitespace

* removes unnecessary import

* a few minor cleanups

* rollback changes to transform browser prefix mixin

* add todo for future trademark helper usage