### PR TITLE
import bootstrap pagination into mars manifest for the seo directory

### DIFF
--- a/app/assets/stylesheets/style_guide/application-mars.scss
+++ b/app/assets/stylesheets/style_guide/application-mars.scss
@@ -1,5 +1,6 @@
 $base-font-path: '../fonts';
 $fa-font-path: '../fonts';
 @import 'bootstrap-custom';
+@import "bootstrap/pagination";
 @import 'font-awesome';
 @import "forever_style_guide/mars_manifest";


### PR DESCRIPTION
not provided by default. store uses it but appears to re-import the full bootstrap on top of the styleguide provided bootstrap.