### PR TITLE
Feature/new responsive nav/154296408

### DIFF
--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -60,6 +60,10 @@ $screen-sm_to_md_custom: 1018px;
 
 .navbar-toggle {
   margin-right: 4px;
+  
+  @media (max-width: $screen-xs) {
+    margin-right: -10px;
+  }
 }
 
 .nav-cart {
@@ -83,12 +87,15 @@ $screen-sm_to_md_custom: 1018px;
     height: $logo-height-small;
     margin-top: 8px;
   }
-  @media (max-width: $screen-sm) {
-    padding-left: $padding-small-horizontal;
+  @media (max-width: 959px) {
     display: inline-block;
+    height: 23px; // mobile height
+    margin-bottom: 13px;
+    margin-top: 7px;
   }
-  @media (max-width: $screen-xs) {
+  @media (max-width: $screen-sm) {
     padding-left: 10px;
+    margin-bottom: 5px;
   }
 }
 
@@ -229,6 +236,12 @@ a.navigation-items-link-deals {
 
   @media (max-width: $screen-lg) {
     font-size: $font-size-400;
+  }
+
+  @media (max-width: 959px) {
+    font-size: 21px;
+    padding-left: 10px;
+    padding-right: 0px;
   }
 }
 
@@ -673,13 +686,33 @@ a.navigation-user_info-logged_out-log_in_link {
 .navbar-right-icons-container,
 .nav > li.navbar-right-icons,
 .navbar-mobile-menu {
-  @media (max-width: $screen-sm) {
+  @media (max-width: 959px) {
     display: inline-block;
+    float: right; //aligns mobile menu
   }
 }
 
 .navbar-right-icons {
   @media (min-width: $screen-lg) {
     margin-top: -4px;
+  }
+}
+
+.visible-mobile {
+  @media (max-width: 959px) {
+    display: inline-block !important;
+  }
+}
+
+
+
+.navbar-nav.navbar-right.navbar-right-icons-container {
+  @media (max-width: 959px) {
+    float: right !important;
+    margin: auto;
+  }
+  @media (max-width: $screen-sm) {
+    margin: 3.5px 0;
+    float: right !important; //aligns mobile menu
   }
 }

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -19,10 +19,6 @@ $screen-mobile-menu: 959px; // when nav converts to colappsed menu
 $logo-height-large: 28px;
 $logo-height-small: 18px;
 
-<<<<<<< HEAD
-// not yet verified
-=======
->>>>>>> b97ae5ed1a80750b55d1c20e8e5dc65faa460ca4
 $letter-spacing-xlarge: 0.6px;
 $letter-spacing-large: 0.5px;
 $letter-spacing-medium: 0.4px;

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -60,7 +60,7 @@ $screen-sm_to_md_custom: 1018px;
 
 .navbar-toggle {
   margin-right: 4px;
-  
+
   @media (max-width: $screen-xs) {
     margin-right: -10px;
   }
@@ -606,7 +606,7 @@ a.navigation-user_info-logged_out-log_in_link {
 }
 
 .nav-mobile-menu {
-  @media (max-width: $screen-sm) {
+  @media (max-width: 959px) {
     width: 0;
     height: 100%;
     background-color: $color-white; /* Black fallback color */
@@ -616,6 +616,21 @@ a.navigation-user_info-logged_out-log_in_link {
     right: 0;
     border-left: solid 1px $color-gray-200;
     opacity: 0.5;
+    top: 80px;
+    max-width: 320px;
+  }
+
+  @media (max-width: $screen-xs) {
+    width: 0;
+    height: 100%;
+    background-color: $color-white; /* Black fallback color */
+    overflow: hidden;
+    position: fixed; /* Stay in place */
+    transition: 0.4s;
+    right: 0;
+    border-left: solid 1px $color-gray-200;
+    opacity: 0.5;
+    max-width: 100%;
   }
 }
 
@@ -633,6 +648,10 @@ a.navigation-user_info-logged_out-log_in_link {
 .navigation-menu-list_item {
   &:active {
     background: inherit;
+  }
+
+  @media (max-width: 959px) {
+    text-align: left;
   }
 
   @media (max-width: $screen-sm) {
@@ -714,5 +733,15 @@ a.navigation-user_info-logged_out-log_in_link {
   @media (max-width: $screen-sm) {
     margin: 3.5px 0;
     float: right !important; //aligns mobile menu
+  }
+}
+
+
+
+.navbar-nav.nav-text_center {
+  @media (max-width: 959px) {
+    float: left !important;
+    margin: 7.5px 0;
+    padding-left: 25px;
   }
 }

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -2,12 +2,8 @@ $navigation-height: 55px;
 $navigation-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
 $navigation-link-hover-transition: color 0.15s ease-in-out;
 $letter-spacing-large: 0.5px;
+$padding-small-horizontal: 3px;
 
-$hamburger-patty-height: 2px;
-$hamburger-patty-width: 20px;
-$hamburger-bun-gap: 6px;
-
-$logo-height-small: 25px;
 $logo-height-large: 28px;
 
 $hover-border-size: 4px;
@@ -47,59 +43,24 @@ $cart-count-vertical-position: -5px;
 }
 
 .navigation {
-  height: 55px;
-  padding: 0 15px;
   box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
   border-bottom: solid 1px $color-gray-200;
 }
 
-.navigation-toggle_button {
-  height: 30px;
-  padding: 0;
-  font-family: inherit;
-  font-size: inherit;
-  background: transparent;
-  border: none;
-  line-height: 0;
-
-  @media screen and (min-width: $screen-md) {
-    display: none;
-  }
-}
-
-.navigation-toggle_button-hamburger {
-  position: relative;
-  display: inline-block;
-  width: $hamburger-patty-width;
-  height: $hamburger-patty-height;
-  background: $color-gray-500;
-
-  &::before,
-  &::after {
-    position: absolute;
-    top: -$hamburger-bun-gap;
-    left: 0;
-    display: inline-block;
-    width: 100%;
-    height: 100%;
-    background: $color-gray-500;
-    content: "";
-  }
-
-  &::after {
-    top: $hamburger-bun-gap;
-  }
-}
-
 .nav-icons {
+  @media (min-width: $screen-md) {
+    padding-top: 15px;
+  }
   padding-top: 10px;
 }
 
 .nav-text_center {
   display: inline-block;
-  float: none;
-  vertical-align: top;
-  text-align: center;
+
+  @media (min-width: $screen-md) {
+    float: none;
+    text-align: center;
+  }
 
   @media (max-width: $screen-md) {
     text-align: left;
@@ -107,70 +68,43 @@ $cart-count-vertical-position: -5px;
   }
 }
 
-.nav.navbar-nav.navbar-right {
-  max-height: 53px;
+.navbar-toggle {
+  margin-right: 4px;
 }
 
-.navbar-toggle {
-  margin-right: 0;
+.nav-cart {
+  @media (min-width: $screen-md) {
+    padding-top: 11px;
+  }
 }
 
 .navbar-nav > li.navigation-user_info-logged_out {
   float: right;
-  padding-top: 8px;
+  padding-top: 6px;
   padding-bottom: 5px;
 }
 
 .navigation-logo_image,
 .navigation-logo {
-  height: $logo-height-small;
+  height: $logo-height-large;
   margin-top: 5px;
-
-  @media screen and (min-width: $screen-lg) {
-    height: $logo-height-large;
-  }
 
   @media (max-width: $screen-sm) {
     padding-left: $padding-small-horizontal;
   }
 }
 
-a.navigation-cart_icon {
-  color: $color-gray-500;
-}
-
-.navigation-menu {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  display: none;
-  width: 100%;
-  background-color: $color-gray-200;
-  padding: $padding-large-vertical $padding-large-horizontal;
-  z-index: -1;
-  box-shadow: $navigation-shadow;
-
-  @media screen and (min-width: $screen-md) {
-    position: static;
-    top: 0;
-    display: flex;
-    align-items: center;
-    width: auto;
-    height: 100%;
-    padding: 0;
-    background: transparent;
-    box-shadow: none;
-    z-index: 100;
-  }
-}
-
 .navigation-menu-list {
+  @media screen and (min-width: $screen-md) {
+    height: 50px;
+  }
+
   height: 100%;
   overflow: hidden;
 }
 
 .navigation-menu-list .navbar-nav > li > a {
-  letter-spacing: .3px;
+  letter-spacing: .4px;
   padding-left: 10px;
   padding-right: 10px;
 
@@ -182,19 +116,11 @@ a.navigation-cart_icon {
 
 .navigation-menu-list_item {
   @media screen and (min-width: $screen-md) {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    height: 100%;
     letter-spacing: .3px;
   }
 
   &:not(:last-of-type) {
     border-bottom: 1px solid $color-gray-300;
-
-    @media screen and (min-width: $screen-md) {
-      border-bottom: 0;
-    }
   }
 }
 
@@ -210,23 +136,14 @@ a.navigation-cart_icon {
 }
 
 a.navigation-items-link {
-  display: block;
   padding-top: $padding-default-vertical;
   padding-bottom: $padding-default-vertical;
   color: $color-gray-600;
   text-transform: uppercase;
 
   @media screen and (min-width: $screen-md) {
-    position: relative;
-    display: inline-flex;
     align-items: center;
     height: 100%;
-    padding-top: 0;
-    padding-bottom: 0;
-    padding-left: 4px;
-    padding-right: 4px;
-    font-size: $font-size-100;
-    letter-spacing: $letter-spacing-large;
     text-decoration: none;
     @include transition($navigation-link-hover-transition);
     @include nav_hover_border(horizontal)
@@ -234,8 +151,6 @@ a.navigation-items-link {
 
   @media screen and (min-width: $screen-lg) {
     font-size: $font-size-200;
-    padding-left: $padding-default-horizontal;
-    padding-right: $padding-default-horizontal;
   }
 
   &:hover {
@@ -265,23 +180,8 @@ a.navigation-items-link-deals {
   height: 100%;
 }
 
-.navigation-user_info-help {
-  @media screen and (min-width: $screen-md) {
-    height: 100%;
-  }
-
-  @media screen and (min-width: $screen-lg) {
-    font-size: $font-size-200;
-  }
-}
-
 .navigation-user_info-help_link {
   @media screen and (min-width: $screen-md) {
-    display: flex;
-    align-items: center;
-    height: 100%;
-    padding-left: $padding-small-horizontal;
-    padding-right: $padding-small-horizontal;
     text-decoration: none;
   }
 
@@ -300,61 +200,20 @@ a.navigation-items-link-deals {
 
   &::after {
     position: relative;
-    top: $deals-icon-vertical-position;
-    right: $deals-icon-horizontal-position;
     font-family: 'FontAwesome';
     font-size: $font-size-000;
     content: "\f005"; // Star
   }
 }
 
-.navigation-user_info {
-  display: flex;
-  align-items: center;
-  height: 100%;
-}
-
-.navigation-user_info-help {
-  @media screen and (min-width: $screen-md) {
-    height: 100%;
-  }
-
-  @media screen and (min-width: $screen-lg) {
-    font-size: $font-size-200;
-  }
-}
-
-.navigation-user_info-help_icon {
+.navigation-user_info-help_icon, .navigation-user_info-cart {
   @include transition($navigation-link-hover-transition);
-}
-
-.navigation-user_info-logged_out {
-  display: flex;
-  align-items: center;
-}
-
-.navigation-user_info-cart {
-
-  @media screen and (min-width: $screen-md) {
-    position: relative;
-    padding-right: $padding-small-horizontal;
-    padding-left: $padding-small-horizontal;
-    @include transition($navigation-link-hover-transition);
-  }
-
-  @media (max-width: $screen-md) {
-    padding-right: $padding-small-horizontal;
-    padding-left: $padding-small-horizontal;
-  }
+  padding-left: $padding-small-horizontal * 1.5;
+  padding-right: $padding-small-horizontal * 1.5;
 }
 
 .navigation-user_info-help_link {
   @media screen and (min-width: $screen-md) {
-    display: flex;
-    align-items: center;
-    height: 100%;
-    padding-left: $padding-small-horizontal;
-    padding-right: $padding-small-horizontal;
     text-decoration: none;
   }
 
@@ -395,7 +254,6 @@ a.navigation-user_info-logged_out-log_in_link {
   @media screen and (min-width: $screen-md) {
     margin-left: $padding-small-horizontal;
     font-size: $font-size-100;
-    letter-spacing: $letter-spacing-large;
   }
 
   @media screen and (min-width: $screen-lg) {
@@ -410,19 +268,20 @@ a.navigation-user_info-logged_out-log_in_link {
 }
 
 // Overriding button styles to make it look good with smaller font size
-.navigation-user_info-logged_out-sign_up_btn {
+a.navigation-user_info-logged_out-sign_up_btn {
   margin-left: $padding-small-horizontal;
-  height: auto !important;
   display: -webkit-box;
+  margin-left: 3px;
 
   @media screen and (min-width: $screen-md) {
     font-size: $font-size-100 !important;
-    letter-spacing: $letter-spacing-large;
+    margin-left: 3px;
   }
 
   @media screen and (min-width: $screen-lg) {
     margin-left: $padding-large-horizontal;
     font-size: $font-size-200 !important;
+    margin-left: 3px;
   }
 }
 
@@ -541,6 +400,7 @@ a.navigation-user_info-logged_out-log_in_link {
   padding-top: $padding-small-vertical;
   padding-bottom: $padding-small-vertical;
   margin-bottom: 0;
+  text-align: left;
 
   &:not(:last-of-type) {
     border-bottom: 2px solid $color-gray-200;
@@ -576,6 +436,7 @@ a.user_info-logged_in-account_dropdown-menu-list-link  {
 
   &:hover {
     color: $color-black;
+
     @media screen and (min-width: $screen-md) {
       color: $color-black;
     }
@@ -631,6 +492,7 @@ a.navigation-user_info-logged_out-log_in_link {
   @media screen and (min-width: $screen-lg) {
     font-size: $font-size-200;
     letter-spacing: 0;
+    margin-left: 0;
   }
 
   &:hover {
@@ -661,4 +523,66 @@ a.navigation-user_info-logged_out-log_in_link {
 
 .navbar-toggle .icon-bar {
   background-color: #666666;
+}
+
+.navbar-nav .open .dropdown-menu {
+  float: left;
+}
+
+ @media screen and (max-width: 768px)
+    {
+        .collapsing
+        {
+            position: absolute !important;
+            z-index: 20;
+            width: 100%;
+            top: 50px;
+            background: white;
+        }
+        .collapse.in {
+            display: block;
+            position: absolute;
+            z-index: 20;
+            width: 100%;
+            top: 50px;
+            background: white;
+        }
+        .navbar-collapse
+        {
+            max-height: none !important;
+        }
+    }
+
+
+.navigation-menu-list_item:not(:last-of-type) {
+  border-bottom: none;
+}
+
+.navbar-nav > li.navigation-user_info-logged_out.navigation-log_in {
+  padding-top: 1px;
+}
+
+.navigation-menu-list .navbar-nav > li > a.navigation-user_info-logged_out-sign_up_btn:hover {
+    color: $color-primary;
+}
+
+
+.nav-sign_in-sign_up {
+  @media (max-width: $screen-sm) {
+    float: left !important;
+  }
+}
+
+
+.collape.in {
+  height: 100%;
+  width: 0;
+  position: fixed; /* Stay in place */
+  z-index: 1; /* Sit on top */
+  left: 0;
+  top: 0;
+  background-color: rgb(0,0,0); /* Black fallback color */
+  background-color: rgba(0,0,0, 0.9); /* Black w/opacity */
+  overflow-x: hidden; /* Disable horizontal scroll */
+  transition: 0.5s;
 }

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -72,6 +72,7 @@ $cart-count-vertical-position: 9px;
     width: 100%;
     padding-bottom: $padding-10;
     border-bottom: solid 1px $color-gray-300;
+    margin-bottom: $padding-10 * 5 !important; // for scrolling to bottom
   }
 
   @media (max-width: $screen-sm) {
@@ -717,6 +718,9 @@ a.navigation-user_info-logged_out-sign_up_btn {
 
 .nav-mobile-menu.top-offset {
   top: 80px;
+  @media (max-width: $screen-xs) {
+    top: 119px;
+  }
 }
 
 .nav-mobile-menu.in {  
@@ -795,4 +799,12 @@ a.navigation-user_info-logged_out-sign_up_btn {
   @media (max-width: $screen-mobile-menu) {
     display: block;
   }
+}
+
+.nav-mobile-menu-account {
+  padding-left: 25px;
+  padding-right: 25px;
+  float: left;
+  width: 100%;
+  background-color: $color-white;
 }

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -19,7 +19,6 @@ $screen-mobile-menu: 959px; // when nav converts to colappsed menu
 $logo-height-large: 28px;
 $logo-height-small: 18px;
 
-// not yet verified
 $letter-spacing-xlarge: 0.6px;
 $letter-spacing-large: 0.5px;
 $letter-spacing-medium: 0.4px;

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -13,7 +13,7 @@ $navigation-link-hover-transition: color 0.15s ease-in-out;
 // spacing and extended desktop view
 $screen-md_to_lg_custom: 1110px;
 $screen-sm_to_md_custom: 1018px;
-$screen-mobile-menu: 959px;
+$screen-mobile-menu: 959px; // when nav converts to colappsed menu
 
 // logo resize for responsiveness
 $logo-height-large: 28px;
@@ -31,6 +31,8 @@ $deals-icon-vertical-position: -5px;
 
 $cart-count-horizontal-position: -11px;
 $cart-count-vertical-position: 9px;
+
+// animation on hover
 
 @mixin nav_hover_border($orientation) {
   &::before {
@@ -70,8 +72,8 @@ $cart-count-vertical-position: 9px;
   float: none;
 
   @media (max-width: $screen-mobile-menu) {
-    padding-left: $padding-10 * 2;
     width: 100%;
+    padding-left: $padding-10 * 2;
     padding-bottom: $padding-10;
     border-bottom: solid 1px $color-gray-300;
     margin-bottom: $padding-10 * 5 !important; // for scrolling to bottom
@@ -79,63 +81,6 @@ $cart-count-vertical-position: 9px;
 
   @media (max-width: $screen-sm) {
     padding-left: $padding-10;
-  }
-}
-
-
-// mobile toggle styling
-
-.navbar-toggle {
-  margin-right: 4px;
-
-  @media (max-width: $screen-md) {
-    margin-right: -10px;
-  }
-}
-
-.navbar-toggle .icon-bar {
-  background-color: $color-gray-600;
-}
-
-// mobile hamburger custom styling for animation
-
-.navbar-toggle.open {
-  border: none;
-  background: transparent;
-
-  &:hover {
-    background: transparent;
-  }
-
-  .icon-bar {
-    width: 22px;
-    transition: all 0.2s;
-  }
-  .top-bar {
-    transform: rotate(45deg);
-    transform-origin: 10% 10%;
-  }
-  .middle-bar {
-    opacity: 0;
-  }
-  .bottom-bar {
-    transform: rotate(-45deg);
-    transform-origin: 10% 90%;
-  }
-}
-
-.navbar-toggle {
-  .top-bar {
-    transform: rotate(0);
-    transition: all 0.2s;
-  }
-  .middle-bar {
-    opacity: 1;
-    transition: all 0.2s;
-  }
-  .bottom-bar {
-    transform: rotate(0);
-    transition: all 0.2s;
   }
 }
 
@@ -160,7 +105,7 @@ $cart-count-vertical-position: 9px;
 //overriding some bootstrap padding on
 .navbar-nav > li.navigation-user_info-logged_out-mobile > a {
   @media (max-width: $screen-mobile-menu) {
-    padding-top: 10px;
+    padding-top: $padding-10;
   }
 }
 
@@ -180,21 +125,21 @@ $cart-count-vertical-position: 9px;
 .navigation-logo_image,
 .navigation-logo {
   height: $logo-height-large;
-  margin-top: 5px;
+  margin-top: $padding-10 / 2;
 
   @media (max-width: $screen-sm_to_md_custom) {
     height: $logo-height-small;
-    margin-top: 8px;
+    margin-top: 8px; // vertical align logo on shrink
   }
   @media (max-width: $screen-mobile-menu) {
     display: inline-block;
-    height: 23px; // mobile height
-    margin-bottom: 13px;
-    margin-top: 7px;
+    height: $logo-height-large; // mobile height
+    margin-top: $padding-10 / 2;
   }
   @media (max-width: $screen-sm) {
-    padding-left: 10px;
-    margin-bottom: 5px;
+    height: $logo-height-small;
+    margin-top: 8px; // vertical align logo on shrink
+    margin-left: $padding-10;
   }
 }
 
@@ -245,7 +190,7 @@ a.navigation-items-link {
     font-size: $font-size-200;
   }
 
-  @media (max-width: 959px) {
+  @media (max-width: $screen-mobile-menu) {
     align-items: center;
     height: 100%;
     text-decoration: none;
@@ -351,7 +296,7 @@ a.navigation-items-link-deals {
 
   @media (max-width: $screen-mobile-menu) {
     font-size: 21px;
-    padding-left: 10px;
+    padding-left: $padding-10;
     padding-right: 0px;
   }
 }
@@ -421,6 +366,10 @@ a.navigation-user_info-logged_out-log_in_link {
       transform: rotate(180deg);
     }
   }
+
+  @media (max-width: $screen-mobile-menu) {
+    display: none; // hides dropdown on mobile
+  }
 }
 
 
@@ -464,7 +413,7 @@ a.navigation-user_info-logged_out-log_in_link {
   background: $color-white;
   box-shadow: 0 5px 20px rgba(0,0,0,.1);
   top: calc(100% + 20px);
-  right: 10px;
+  right: $padding-10;
   padding: $padding-large-vertical $padding-large-horizontal;
   padding-bottom: 0;
   width: 300px;
@@ -639,7 +588,7 @@ a.navigation-user_info-logged_out-sign_up_btn {
   
   display: -webkit-box;
   margin-left: 4px;
-  margin-right: 10px;
+  margin-right: $padding-10;
 
   @media screen and (min-width: $screen-md) {
     font-size: $font-size-100 !important;
@@ -717,7 +666,13 @@ a.navigation-user_info-logged_out-sign_up_btn {
 }
 
 .nav-mobile-menu.top-offset {
-  top: 80px;
+  @media (max-width: $screen-mobile-menu) {
+    top: 80px;
+  }
+
+  @media (max-width: $screen-xs) {
+    top: 121px;
+  }
 }
 
 .nav-mobile-menu-account.visible-mobile {
@@ -737,6 +692,11 @@ a.navigation-user_info-logged_out-sign_up_btn {
   opacity: 1;
   border-left: solid 1px $color-gray-200;
   box-shadow: $navigation-shadow;
+
+  @media (max-width: $screen-mobile-menu) {
+    padding-top: 15px;
+    background: $color-white;
+  }
 }
 
 .navigation-menu-list_item {
@@ -750,7 +710,7 @@ a.navigation-user_info-logged_out-sign_up_btn {
 
   @media (max-width: $screen-sm) {
     min-width: 300px;
-    margin-left: 10px;
+    margin-left: $padding-10;
   }
 }
 
@@ -765,7 +725,7 @@ a.navigation-user_info-logged_out-sign_up_btn {
 
 .navbar-right-icons {
   @media (min-width: $screen-lg) {
-    margin-top: -4px;
+    margin-top: -4px; // vertically aligns custom sizes icons on desktop
   }
 }
 
@@ -773,13 +733,13 @@ a.navigation-user_info-logged_out-sign_up_btn {
   display: none !important;
 
   @media (max-width: $screen-mobile-menu) {
-    display: inline-block !important;
+    display: inline-block !important; // required to override shame.scss
   }
 }
 
 .hidden-mobile {
   @media (max-width: $screen-mobile-menu) {
-    display: none !important;
+    display: none !important; // hides duplicated cart and help on collapse
   }
 }
 
@@ -794,10 +754,6 @@ a.navigation-user_info-logged_out-sign_up_btn {
   }
 }
 
-.navigation-list-container {
-  height: 50px;
-}
-
 .navigation-user_info-logged_out-container {
   @media (max-width: $screen-mobile-menu) {
     display: block;
@@ -810,4 +766,66 @@ a.navigation-user_info-logged_out-sign_up_btn {
   float: left;
   width: 100%;
   background-color: $color-white;
+}
+
+// mobile toggle styling
+// customer hamburger
+
+$padding-10: 10px;
+$nav-icon_bar-width: 22px;
+
+.navbar-toggle {
+  @media (max-width: $screen-md) {
+    margin-right: -10px; // equalize padding between right-side icons
+    margin-left: $padding-10;
+  }
+  @media (max-width: $screen-xs) {
+    margin-left: 0;
+  }
+}
+
+.navbar-toggle .icon-bar {
+  background-color: $color-gray-600; // specificity required to override
+}
+
+// mobile hamburger custom styling for animation
+
+.navbar-toggle.open {
+  border: none;
+  background: transparent;
+
+  &:hover {
+    background: transparent;
+  }
+
+  .icon-bar {
+    width: $nav-icon_bar-width;
+    transition: all 0.2s;
+  }
+  .top-bar {
+    transform: rotate(45deg);
+    transform-origin: 10% 10%;
+  }
+  .middle-bar {
+    opacity: 0;
+  }
+  .bottom-bar {
+    transform: rotate(-45deg);
+    transform-origin: 10% 90%;
+  }
+}
+
+.navbar-toggle {
+  .top-bar {
+    transform: rotate(0);
+    transition: all 0.2s;
+  }
+  .middle-bar {
+    opacity: 1;
+    transition: all 0.2s;
+  }
+  .bottom-bar {
+    transform: rotate(0);
+    transition: all 0.2s;
+  }
 }

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -7,7 +7,7 @@ $hamburger-patty-height: 2px;
 $hamburger-patty-width: 20px;
 $hamburger-bun-gap: 6px;
 
-$logo-height-small: 20px;
+$logo-height-small: 25px;
 $logo-height-large: 28px;
 
 $hover-border-size: 4px;
@@ -47,12 +47,10 @@ $cart-count-vertical-position: -5px;
 }
 
 .navigation {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: $navigation-height;
-  padding: 0 $padding-large-horizontal;
-  box-shadow: $navigation-shadow;
+  height: 55px;
+  padding: 0 15px;
+  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
+  border-bottom: solid 1px $color-gray-200;
 }
 
 .navigation-toggle_button {
@@ -93,12 +91,47 @@ $cart-count-vertical-position: -5px;
   }
 }
 
+.nav-icons {
+  padding-top: 10px;
+}
+
+.nav-text_center {
+  display: inline-block;
+  float: none;
+  vertical-align: top;
+  text-align: center;
+
+  @media (max-width: $screen-md) {
+    text-align: left;
+    width: 100%;
+  }
+}
+
+.nav.navbar-nav.navbar-right {
+  max-height: 53px;
+}
+
+.navbar-toggle {
+  margin-right: 0;
+}
+
+.navbar-nav > li.navigation-user_info-logged_out {
+  float: right;
+  padding-top: 8px;
+  padding-bottom: 5px;
+}
+
 .navigation-logo_image,
 .navigation-logo {
   height: $logo-height-small;
+  margin-top: 5px;
 
   @media screen and (min-width: $screen-lg) {
     height: $logo-height-large;
+  }
+
+  @media (max-width: $screen-sm) {
+    padding-left: $padding-small-horizontal;
   }
 }
 
@@ -136,12 +169,24 @@ a.navigation-cart_icon {
   overflow: hidden;
 }
 
+.navigation-menu-list .navbar-nav > li > a {
+  letter-spacing: .3px;
+  padding-left: 10px;
+  padding-right: 10px;
+
+  &:hover {
+    color: $color-secondary;
+    background-color: inherit;
+  }
+}
+
 .navigation-menu-list_item {
   @media screen and (min-width: $screen-md) {
     position: relative;
     display: inline-flex;
     align-items: center;
     height: 100%;
+    letter-spacing: .3px;
   }
 
   &:not(:last-of-type) {
@@ -289,25 +334,15 @@ a.navigation-items-link-deals {
 }
 
 .navigation-user_info-cart {
-  position: absolute;
-  background-color: #999;
-  visibility: hidden;
-  padding-right: $padding-small-horizontal;
-  padding-left: $padding-small-horizontal;
-  @include transition($navigation-link-hover-transition);
-  color: red !important;
 
   @media screen and (min-width: $screen-md) {
-    position: absolute;
-    background-color: #999;
-    visibility: hidden;
+    position: relative;
     padding-right: $padding-small-horizontal;
     padding-left: $padding-small-horizontal;
     @include transition($navigation-link-hover-transition);
-    color: red !important;
   }
 
-  @media (max-width: $screen-sm) {
+  @media (max-width: $screen-md) {
     padding-right: $padding-small-horizontal;
     padding-left: $padding-small-horizontal;
   }
@@ -378,6 +413,7 @@ a.navigation-user_info-logged_out-log_in_link {
 .navigation-user_info-logged_out-sign_up_btn {
   margin-left: $padding-small-horizontal;
   height: auto !important;
+  display: -webkit-box;
 
   @media screen and (min-width: $screen-md) {
     font-size: $font-size-100 !important;
@@ -623,10 +659,6 @@ a.navigation-user_info-logged_out-log_in_link {
   color: $color-danger !important;
 }
 
-.letter-spacing-small {
-  letter-spacing: 0.3px;
-}
-
-.letter-spacing-large {
-  letter-spacing: 0.5px;
+.navbar-toggle .icon-bar {
+  background-color: #666666;
 }

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -5,6 +5,8 @@ $letter-spacing-large: 0.5px;
 $padding-small-horizontal: 3px;
 
 $logo-height-large: 28px;
+$logo-height-small: 18px;
+
 
 $hover-border-size: 4px;
 
@@ -13,6 +15,9 @@ $deals-icon-vertical-position: -5px;
 
 $cart-count-horizontal-position: -15px;
 $cart-count-vertical-position: -5px;
+
+$screen-md_to_lg_custom: 1110px;
+$screen-sm_to_md_custom: 1018px;
 
 @mixin nav_hover_border($orientation) {
   &::before {
@@ -47,25 +52,10 @@ $cart-count-vertical-position: -5px;
   border-bottom: solid 1px $color-gray-200;
 }
 
-.nav-icons {
-  @media (min-width: $screen-md) {
-    padding-top: 15px;
-  }
-  padding-top: 10px;
-}
-
 .nav-text_center {
   display: inline-block;
-
-  @media (min-width: $screen-md) {
-    float: none;
-    text-align: center;
-  }
-
-  @media (max-width: $screen-md) {
-    text-align: left;
-    width: 100%;
-  }
+  float: none;
+  text-align: center;
 }
 
 .navbar-toggle {
@@ -89,8 +79,13 @@ $cart-count-vertical-position: -5px;
   height: $logo-height-large;
   margin-top: 5px;
 
+  @media (max-width: $screen-sm_to_md_custom) {
+    height: $logo-height-small;
+    margin-top: 8px;
+  }
   @media (max-width: $screen-sm) {
     padding-left: $padding-small-horizontal;
+    display: inline-block;
   }
   @media (max-width: $screen-xs) {
     padding-left: 10px;
@@ -98,7 +93,7 @@ $cart-count-vertical-position: -5px;
 }
 
 .navigation-menu-list {
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: $screen-sm) {
     height: 50px;
   }
 
@@ -106,20 +101,10 @@ $cart-count-vertical-position: -5px;
   overflow: hidden;
 }
 
-.navigation-menu-list .navbar-nav > li > a {
-  letter-spacing: .4px;
-  padding-left: 10px;
-  padding-right: 10px;
-
-  &:hover {
-    color: $color-secondary;
-    background-color: inherit;
-  }
-}
 
 .navigation-menu-list_item {
-  @media screen and (min-width: $screen-md) {
-    letter-spacing: .3px;
+  @media screen and (min-width: $screen-xs) {
+    letter-spacing: .4px;
   }
 
   &:not(:last-of-type) {
@@ -144,7 +129,7 @@ a.navigation-items-link {
   color: $color-gray-600;
   text-transform: uppercase;
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: $screen-sm) {
     align-items: center;
     height: 100%;
     text-decoration: none;
@@ -157,7 +142,7 @@ a.navigation-items-link {
   }
 
   &:hover {
-    @media screen and (min-width: $screen-md) {
+    @media screen and (min-width: $screen-sm) {
       color: $color-secondary;
     }
   }
@@ -165,7 +150,7 @@ a.navigation-items-link {
 
 a.navigation-items-link-deals {
   position: relative;
-  color: $color-danger;
+  color: $color-warning;
 
   &::after {
     position: relative;
@@ -174,6 +159,18 @@ a.navigation-items-link-deals {
     font-family: 'FontAwesome';
     font-size: $font-size-000;
     content: "\f005"; // Star
+  }
+
+  @media (max-width: $screen-md_to_lg) {
+    &::after {
+    font-size: $font-size-100 - 1;
+    }
+  }
+
+  @media (max-width: $screen-sm) {
+    &::after {
+    content: none;
+    }
   }
 }
 
@@ -197,22 +194,42 @@ a.navigation-items-link-deals {
   }
 }
 
-a.navigation-items-link-deals {
-  position: relative;
-  color: $color-warning;
+.navigation-menu-list .navbar-nav > li > a {
+  letter-spacing: .6px;
+  padding-left: 10px;
+  padding-right: 10px;
 
-  &::after {
-    position: relative;
-    font-family: 'FontAwesome';
-    font-size: $font-size-000;
-    content: "\f005"; // Star
+  &:hover {
+    color: $color-secondary;
+    background-color: inherit;
+  }
+
+  @media (max-width: $screen-lg) {
+    padding-left: 7px;
+    padding-right: 7px;
+    font-size: $font-size-200;
+  }
+
+  @media (max-width: $screen-md_to_lg_custom) {
+    padding-left: 5px;
+    padding-right: 5px;
+    letter-spacing: .5px;
+  }
+
+  @media (max-width: $screen-md_to_lg) {
+    font-size: $font-size-200 - 1;
   }
 }
 
-.navigation-user_info-help_icon, .navigation-user_info-cart {
+.navigation-menu-list .navbar-nav > li > a.navigation-user_info-cart,
+.navigation-menu-list .navbar-nav > li > a .navigation-user_info-help_icon {
   @include transition($navigation-link-hover-transition);
-  padding-left: $padding-small-horizontal * 1.5;
-  padding-right: $padding-small-horizontal * 1.5;
+  padding-left: $padding-small-horizontal;
+  padding-right: $padding-small-horizontal;
+
+  @media (max-width: $screen-lg) {
+    font-size: $font-size-400;
+  }
 }
 
 .navigation-user_info-help_link {
@@ -422,7 +439,7 @@ a.user_info-logged_in-account_dropdown-menu-list-link  {
   text-decoration: none;
 
   &::before {
-    @media screen and (min-width: $screen-md) {
+    @media screen and (min-width: $screen-xs) {
       position: absolute;
       bottom: 0;
       left: 0;
@@ -439,12 +456,12 @@ a.user_info-logged_in-account_dropdown-menu-list-link  {
   &:hover {
     color: $color-black;
 
-    @media screen and (min-width: $screen-md) {
+    @media screen and (min-width: $screen-xs) {
       color: $color-black;
     }
 
     &::before {
-      @media screen and (min-width: $screen-md) {
+      @media screen and (min-width: $screen-xs) {
         transform: scaleX(1);
         transition: transform 0.25s ease-in-out;
       }
@@ -527,33 +544,33 @@ a.navigation-user_info-logged_out-log_in_link {
   background-color: #666666;
 }
 
+/*
 .navbar-nav .open .dropdown-menu {
   float: left;
 }
-
- @media screen and (max-width: 768px)
-    {
-        .collapsing
-        {
-            position: absolute !important;
-            z-index: 20;
-            width: 100%;
-            top: 50px;
-            background: white;
-        }
-        .collapse.in {
-            display: block;
-            position: absolute;
-            z-index: 20;
-            width: 100%;
-            top: 50px;
-            background: white;
-        }
-        .navbar-collapse
-        {
-            max-height: none !important;
-        }
-    }
+*/
+ @media screen and (max-width: 768px) {
+  .collapsing
+  {
+      position: absolute !important;
+      z-index: 20;
+      width: 100%;
+      top: 50px;
+      background: white;
+  }
+  .collapse.in {
+      display: block;
+      position: absolute;
+      z-index: 20;
+      width: 100%;
+      top: 50px;
+      background: white;
+  }
+  .navbar-collapse
+  {
+      max-height: none !important;
+  }
+}
 
 
 .navigation-menu-list_item:not(:last-of-type) {
@@ -561,7 +578,7 @@ a.navigation-user_info-logged_out-log_in_link {
 }
 
 .navbar-nav > li.navigation-user_info-logged_out.navigation-log_in {
-  padding-top: 1px;
+  padding-top: 0;
 }
 
 .navigation-menu-list .navbar-nav > li > a.navigation-user_info-logged_out-sign_up_btn:hover {
@@ -570,12 +587,12 @@ a.navigation-user_info-logged_out-log_in_link {
 
 
 .nav-sign_in-sign_up {
-  @media (max-width: $screen-sm) {
+  @media (max-width: $screen-xs) {
     float: left !important;
   }
 }
 
-.collapse2 {
+.nav-mobile-menu {
   @media (max-width: $screen-sm) {
     width: 0;
     height: 100%;
@@ -585,17 +602,19 @@ a.navigation-user_info-logged_out-log_in_link {
     transition: 0.4s;
     right: 0;
     border-left: solid 1px $color-gray-200;
+    opacity: 0.5;
   }
 }
 
-.collapse2.in {  
+.nav-mobile-menu.in {  
   height: 100%;
   width: 100%;
   z-index: 1; /* Sit on top */
   right: 0;
   overflow-x: hidden; /* Disable horizontal scroll */
   overflow-y: hidden;
-  transition: 1s;
+  transition: 0.5s;
+  opacity: 1;
 }
 
 .navigation-menu-list_item {
@@ -608,6 +627,8 @@ a.navigation-user_info-logged_out-log_in_link {
     margin-left: 10px;
   }
 }
+
+// mobile hamburger
 
 .navbar-toggle.open {
   border: none;
@@ -637,11 +658,28 @@ a.navigation-user_info-logged_out-log_in_link {
 .navbar-toggle {
   .top-bar {
     transform: rotate(0);
+    transition: all 0.2s;
   }
   .middle-bar {
     opacity: 1;
+    transition: all 0.2s;
   }
   .bottom-bar {
     transform: rotate(0);
+    transition: all 0.2s;
+  }
+}
+
+.navbar-right-icons-container,
+.nav > li.navbar-right-icons,
+.navbar-mobile-menu {
+  @media (max-width: $screen-sm) {
+    display: inline-block;
+  }
+}
+
+.navbar-right-icons {
+  @media (min-width: $screen-lg) {
+    margin-top: -4px;
   }
 }

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -584,7 +584,6 @@ a.navigation-user_info-logged_out-log_in_link {
     position: fixed; /* Stay in place */
     transition: 0.4s;
     right: 0;
-    border-top: solid 1px $color-gray-200;
     border-left: solid 1px $color-gray-200;
   }
 }

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -723,8 +723,6 @@ a.navigation-user_info-logged_out-log_in_link {
   }
 }
 
-
-
 .navbar-nav.navbar-right.navbar-right-icons-container {
   @media (max-width: 959px) {
     float: right !important;
@@ -735,8 +733,6 @@ a.navigation-user_info-logged_out-log_in_link {
     float: right !important; //aligns mobile menu
   }
 }
-
-
 
 .navbar-nav.nav-text_center {
   @media (max-width: 959px) {

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -668,10 +668,6 @@ a.navigation-user_info-logged_out-sign_up_btn {
   @media (max-width: $screen-mobile-menu) {
     top: 80px;
   }
-
-  @media (max-width: $screen-xs) {
-    top: 121px;
-  }
 }
 
 .nav-mobile-menu-account.visible-mobile {

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -1,23 +1,34 @@
+// main nav
+$navigation-shadow: 0 3px 5px rgba(0, 0, 0, 0.1);
+
+// custom padding
+$padding-10: 10px;
+
+// animation varibales
+$hover-border-size: 4px;
+
+// custom breakpoints to accomodate tight
+// spacing and extended desktop view
+$screen-md_to_lg_custom: 1110px;
+$screen-sm_to_md_custom: 1018px;
+$screen-mobile-menu: 959px;
+
+// logo resize for responsiveness
+$logo-height-large: 28px;
+$logo-height-small: 18px;
+
+// not yet verified
 $navigation-height: 55px;
-$navigation-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
 $navigation-link-hover-transition: color 0.15s ease-in-out;
 $letter-spacing-large: 0.5px;
 $padding-small-horizontal: 3px;
 
-$logo-height-large: 28px;
-$logo-height-small: 18px;
-
-
-$hover-border-size: 4px;
 
 $deals-icon-horizontal-position: -3px;
 $deals-icon-vertical-position: -5px;
 
-$cart-count-horizontal-position: -15px;
-$cart-count-vertical-position: -5px;
-
-$screen-md_to_lg_custom: 1110px;
-$screen-sm_to_md_custom: 1018px;
+$cart-count-horizontal-position: -11px;
+$cart-count-vertical-position: 9px;
 
 @mixin nav_hover_border($orientation) {
   &::before {
@@ -48,27 +59,88 @@ $screen-sm_to_md_custom: 1018px;
 }
 
 .navigation {
-  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
-  border-bottom: solid 1px $color-gray-200;
+  box-shadow: $navigation-shadow;
+  border-bottom: solid 1px $color-gray-300;
 }
 
 .nav-text_center {
   display: inline-block;
   float: none;
-  text-align: center;
+
+  @media (max-width: $screen-mobile-menu) {
+    padding-left: $padding-10 * 2;
+    width: 100%;
+    padding-bottom: $padding-10;
+    border-bottom: solid 1px $color-gray-300;
+  }
+
+  @media (max-width: $screen-sm) {
+    padding-left: $padding-10;
+  }
 }
+
+
+// mobile toggle styling
 
 .navbar-toggle {
   margin-right: 4px;
 
-  @media (max-width: $screen-xs) {
+  @media (max-width: $screen-md) {
     margin-right: -10px;
   }
 }
 
+.navbar-toggle .icon-bar {
+  background-color: $color-gray-600;
+}
+
+// mobile hamburger custom styling for animation
+
+.navbar-toggle.open {
+  border: none;
+  background: transparent;
+
+  &:hover {
+    background: transparent;
+  }
+
+  .icon-bar {
+    width: 22px;
+    transition: all 0.2s;
+  }
+  .top-bar {
+    transform: rotate(45deg);
+    transform-origin: 10% 10%;
+  }
+  .middle-bar {
+    opacity: 0;
+  }
+  .bottom-bar {
+    transform: rotate(-45deg);
+    transform-origin: 10% 90%;
+  }
+}
+
+.navbar-toggle {
+  .top-bar {
+    transform: rotate(0);
+    transition: all 0.2s;
+  }
+  .middle-bar {
+    opacity: 1;
+    transition: all 0.2s;
+  }
+  .bottom-bar {
+    transform: rotate(0);
+    transition: all 0.2s;
+  }
+}
+
+// cart stytling
+
 .nav-cart {
   @media (min-width: $screen-md) {
-    padding-top: 11px;
+    padding-top: $padding-10 + 1;
   }
 }
 
@@ -76,6 +148,30 @@ $screen-sm_to_md_custom: 1018px;
   float: right;
   padding-top: 6px;
   padding-bottom: 5px;
+
+  @media (max-width: $screen-mobile-menu) {
+    display: none;
+  }
+}
+
+//overriding some bootstrap padding on
+.navbar-nav > li.navigation-user_info-logged_out-mobile > a {
+  @media (max-width: $screen-mobile-menu) {
+    padding-top: 10px;
+  }
+}
+
+.navbar-nav > li.navigation-user_info-logged_out-mobile {
+  display: none;
+
+  @media (max-width: $screen-mobile-menu) {
+    display: block;
+    padding: 5px 20px;
+  }
+}
+
+.navbar-right {
+  max-height: 50px;
 }
 
 .navigation-logo_image,
@@ -87,7 +183,7 @@ $screen-sm_to_md_custom: 1018px;
     height: $logo-height-small;
     margin-top: 8px;
   }
-  @media (max-width: 959px) {
+  @media (max-width: $screen-mobile-menu) {
     display: inline-block;
     height: 23px; // mobile height
     margin-bottom: 13px;
@@ -105,9 +201,7 @@ $screen-sm_to_md_custom: 1018px;
   }
 
   height: 100%;
-  overflow: hidden;
 }
-
 
 .navigation-menu-list_item {
   @media screen and (min-width: $screen-xs) {
@@ -147,6 +241,19 @@ a.navigation-items-link {
   @media screen and (min-width: $screen-lg) {
     font-size: $font-size-200;
   }
+
+  @media (max-width: 959px) {
+    align-items: center;
+    height: 100%;
+    text-decoration: none;
+    @include transition($navigation-link-hover-transition);
+    @include nav_hover_border(vertical)
+
+    &:before {
+      left: -20px;
+    }
+  }
+
 
   &:hover {
     @media screen and (min-width: $screen-sm) {
@@ -205,6 +312,7 @@ a.navigation-items-link-deals {
   letter-spacing: .6px;
   padding-left: 10px;
   padding-right: 10px;
+  max-height: 50px;
 
   &:hover {
     color: $color-secondary;
@@ -238,7 +346,7 @@ a.navigation-items-link-deals {
     font-size: $font-size-400;
   }
 
-  @media (max-width: 959px) {
+  @media (max-width: $screen-mobile-menu) {
     font-size: 21px;
     padding-left: 10px;
     padding-right: 0px;
@@ -274,7 +382,7 @@ a.navigation-items-link-deals {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0 7px 0 6px; // To make it look like a circle with 1 item in cart
+  padding: 0 6px 0 7px; // To make it look like a circle with 1 item in cart
   border-radius: 50px; // To get it looking like a pill when more items are added
 }
 
@@ -300,27 +408,18 @@ a.navigation-user_info-logged_out-log_in_link {
   }
 }
 
-// Overriding button styles to make it look good with smaller font size
-a.navigation-user_info-logged_out-sign_up_btn {
-  display: -webkit-box;
-  margin-left: 4px;
-  margin-right: 10px;
-
-  @media screen and (min-width: $screen-md) {
-    font-size: $font-size-100 !important;
-    margin-left: 3px;
-  }
-
-  @media screen and (min-width: $screen-lg) {
-    font-size: $font-size-200 !important;
-    margin-left: 3px;
-  }
-}
-
 .navigation-user_info-logged_in {
   height: 100%;
-  margin-left: $padding-default-horizontal;
+  margin-top: 7px;
+  margin-right: 15px;
+
+  &.open {
+    .user_info-logged_in-account_dropdown_trigger-icon {
+      transform: rotate(180deg);
+    }
+  }
 }
+
 
 .user_info-logged_in-account_dropdown_trigger {
   display: flex;
@@ -333,12 +432,6 @@ a.navigation-user_info-logged_out-sign_up_btn {
 
   &:hover {
     opacity: 0.7;
-  }
-
-  &.open {
-    .user_info-logged_in-account_dropdown_trigger-icon {
-      transform: rotate(180deg);
-    }
   }
 }
 
@@ -364,7 +457,6 @@ a.navigation-user_info-logged_out-sign_up_btn {
 }
 
 .user_info-logged_in-account_dropdown {
-  display: none;
   position: absolute;
   background: $color-white;
   box-shadow: 0 5px 20px rgba(0,0,0,.1);
@@ -383,7 +475,6 @@ a.navigation-user_info-logged_out-sign_up_btn {
     height: 0;
     border-left: 10px solid transparent;
     border-right: 10px solid transparent;
-
     border-bottom: 10px solid $color-white;
   }
 
@@ -464,13 +555,16 @@ a.user_info-logged_in-account_dropdown-menu-list-link  {
       transition: transform 0.15s ease-in-out;
       transform-origin: left;
     }
+    @media (max-width: $screen-mobile-menu) {
+      left: -20px;
+    }
   }
 
   &:hover {
-    color: $color-black;
+    color: $color-secondary;
 
     @media screen and (min-width: $screen-xs) {
-      color: $color-black;
+      color: $color-secondary;
     }
 
     &::before {
@@ -534,34 +628,31 @@ a.navigation-user_info-logged_out-log_in_link {
 }
 
 // Overriding button styles to make it look good with smaller font size
-.navigation-user_info-logged_out-sign_up_btn {
-  margin-left: $padding-small-horizontal;
-  height: auto !important;
+a.navigation-user_info-logged_out-sign_up_btn {
+  @media screen and (max-width: $screen-mobile-menu) {
+    width: 120px;
+  }
+  
+  display: -webkit-box;
+  margin-left: 4px;
+  margin-right: 10px;
 
   @media screen and (min-width: $screen-md) {
     font-size: $font-size-100 !important;
-    letter-spacing: $letter-spacing-large;
+    margin-left: 3px;
   }
 
   @media screen and (min-width: $screen-lg) {
-    margin-left: $padding-large-horizontal;
     font-size: $font-size-200 !important;
+    margin-left: 3px;
   }
 }
+
 
 .user_info-logged_in-account_dropdown-menu-list-sign_out {
   color: $color-danger !important;
 }
 
-.navbar-toggle .icon-bar {
-  background-color: #666666;
-}
-
-/*
-.navbar-nav .open .dropdown-menu {
-  float: left;
-}
-*/
  @media screen and (max-width: 768px) {
   .collapsing
   {
@@ -581,7 +672,7 @@ a.navigation-user_info-logged_out-log_in_link {
   }
   .navbar-collapse
   {
-      max-height: none !important;
+    max-height: none !important;
   }
 }
 
@@ -606,43 +697,39 @@ a.navigation-user_info-logged_out-log_in_link {
 }
 
 .nav-mobile-menu {
-  @media (max-width: 959px) {
+  @media (max-width: $screen-mobile-menu) {
     width: 0;
     height: 100%;
-    background-color: $color-white; /* Black fallback color */
+    background-color: $color-gray-100; /* Black fallback color */
     overflow: hidden;
     position: fixed; /* Stay in place */
     transition: 0.4s;
     right: 0;
     border-left: solid 1px $color-gray-200;
     opacity: 0.5;
-    top: 80px;
     max-width: 320px;
   }
 
   @media (max-width: $screen-xs) {
-    width: 0;
-    height: 100%;
-    background-color: $color-white; /* Black fallback color */
-    overflow: hidden;
-    position: fixed; /* Stay in place */
-    transition: 0.4s;
-    right: 0;
-    border-left: solid 1px $color-gray-200;
-    opacity: 0.5;
     max-width: 100%;
   }
+}
+
+.nav-mobile-menu.top-offset {
+  top: 80px;
 }
 
 .nav-mobile-menu.in {  
   height: 100%;
   width: 100%;
-  z-index: 1; /* Sit on top */
+  z-index: $zindex-tooltip; /* Sit on top */
   right: 0;
   overflow-x: hidden; /* Disable horizontal scroll */
-  overflow-y: hidden;
+  overflow-y: auto;
   transition: 0.5s;
   opacity: 1;
+  border-left: solid 1px $color-gray-200;
+  box-shadow: $navigation-shadow;
 }
 
 .navigation-menu-list_item {
@@ -650,7 +737,7 @@ a.navigation-user_info-logged_out-log_in_link {
     background: inherit;
   }
 
-  @media (max-width: 959px) {
+  @media (max-width: $screen-mobile-menu) {
     text-align: left;
   }
 
@@ -660,52 +747,10 @@ a.navigation-user_info-logged_out-log_in_link {
   }
 }
 
-// mobile hamburger
-
-.navbar-toggle.open {
-  border: none;
-  background: transparent !important;
-
-  &:hover {
-    background: transparent !important;
-  }
-
-  .icon-bar {
-    width: 22px;
-    transition: all 0.2s;
-  }
-  .top-bar {
-    transform: rotate(45deg);
-    transform-origin: 10% 10%;
-  }
-  .middle-bar {
-    opacity: 0;
-  }
-  .bottom-bar {
-    transform: rotate(-45deg);
-    transform-origin: 10% 90%;
-  }
-}
-
-.navbar-toggle {
-  .top-bar {
-    transform: rotate(0);
-    transition: all 0.2s;
-  }
-  .middle-bar {
-    opacity: 1;
-    transition: all 0.2s;
-  }
-  .bottom-bar {
-    transform: rotate(0);
-    transition: all 0.2s;
-  }
-}
-
 .navbar-right-icons-container,
 .nav > li.navbar-right-icons,
 .navbar-mobile-menu {
-  @media (max-width: 959px) {
+  @media (max-width: $screen-mobile-menu) {
     display: inline-block;
     float: right; //aligns mobile menu
   }
@@ -718,13 +763,21 @@ a.navigation-user_info-logged_out-log_in_link {
 }
 
 .visible-mobile {
-  @media (max-width: 959px) {
+  display: none !important;
+
+  @media (max-width: $screen-mobile-menu) {
     display: inline-block !important;
   }
 }
 
+.hidden-mobile {
+  @media (max-width: $screen-mobile-menu) {
+    display: none !important;
+  }
+}
+
 .navbar-nav.navbar-right.navbar-right-icons-container {
-  @media (max-width: 959px) {
+  @media (max-width: $screen-mobile-menu) {
     float: right !important;
     margin: auto;
   }
@@ -734,10 +787,12 @@ a.navigation-user_info-logged_out-log_in_link {
   }
 }
 
-.navbar-nav.nav-text_center {
-  @media (max-width: 959px) {
-    float: left !important;
-    margin: 7.5px 0;
-    padding-left: 25px;
+.navigation-list-container {
+  height: 50px;
+}
+
+.navigation-user_info-logged_out-container {
+  @media (max-width: $screen-mobile-menu) {
+    display: block;
   }
 }

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -92,6 +92,9 @@ $cart-count-vertical-position: -5px;
   @media (max-width: $screen-sm) {
     padding-left: $padding-small-horizontal;
   }
+  @media (max-width: $screen-xs) {
+    padding-left: 10px;
+  }
 }
 
 .navigation-menu-list {
@@ -269,9 +272,9 @@ a.navigation-user_info-logged_out-log_in_link {
 
 // Overriding button styles to make it look good with smaller font size
 a.navigation-user_info-logged_out-sign_up_btn {
-  margin-left: $padding-small-horizontal;
   display: -webkit-box;
-  margin-left: 3px;
+  margin-left: 4px;
+  margin-right: 10px;
 
   @media screen and (min-width: $screen-md) {
     font-size: $font-size-100 !important;
@@ -279,7 +282,6 @@ a.navigation-user_info-logged_out-sign_up_btn {
   }
 
   @media screen and (min-width: $screen-lg) {
-    margin-left: $padding-large-horizontal;
     font-size: $font-size-200 !important;
     margin-left: 3px;
   }
@@ -573,16 +575,74 @@ a.navigation-user_info-logged_out-log_in_link {
   }
 }
 
+.collapse2 {
+  @media (max-width: $screen-sm) {
+    width: 0;
+    height: 100%;
+    background-color: $color-white; /* Black fallback color */
+    overflow: hidden;
+    position: fixed; /* Stay in place */
+    transition: 0.4s;
+    right: 0;
+    border-top: solid 1px $color-gray-200;
+    border-left: solid 1px $color-gray-200;
+  }
+}
 
-.collape.in {
+.collapse2.in {  
   height: 100%;
-  width: 0;
-  position: fixed; /* Stay in place */
+  width: 100%;
   z-index: 1; /* Sit on top */
-  left: 0;
-  top: 0;
-  background-color: rgb(0,0,0); /* Black fallback color */
-  background-color: rgba(0,0,0, 0.9); /* Black w/opacity */
+  right: 0;
   overflow-x: hidden; /* Disable horizontal scroll */
-  transition: 0.5s;
+  overflow-y: hidden;
+  transition: 1s;
+}
+
+.navigation-menu-list_item {
+  &:active {
+    background: inherit;
+  }
+
+  @media (max-width: $screen-sm) {
+    min-width: 300px;
+    margin-left: 10px;
+  }
+}
+
+.navbar-toggle.open {
+  border: none;
+  background: transparent !important;
+
+  &:hover {
+    background: transparent !important;
+  }
+
+  .icon-bar {
+    width: 22px;
+    transition: all 0.2s;
+  }
+  .top-bar {
+    transform: rotate(45deg);
+    transform-origin: 10% 10%;
+  }
+  .middle-bar {
+    opacity: 0;
+  }
+  .bottom-bar {
+    transform: rotate(-45deg);
+    transform-origin: 10% 90%;
+  }
+}
+
+.navbar-toggle {
+  .top-bar {
+    transform: rotate(0);
+  }
+  .middle-bar {
+    opacity: 1;
+  }
+  .bottom-bar {
+    transform: rotate(0);
+  }
 }

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -202,7 +202,7 @@ a.navigation-items-link {
 
 a.navigation-items-link-deals {
   position: relative;
-  color: $color-warning;
+  color: $color-danger;
 
   &::after {
     position: relative;
@@ -289,11 +289,27 @@ a.navigation-items-link-deals {
 }
 
 .navigation-user_info-cart {
+  position: absolute;
+  background-color: #999;
+  visibility: hidden;
+  padding-right: $padding-small-horizontal;
+  padding-left: $padding-small-horizontal;
+  @include transition($navigation-link-hover-transition);
+  color: red !important;
+
   @media screen and (min-width: $screen-md) {
-    position: relative;
+    position: absolute;
+    background-color: #999;
+    visibility: hidden;
     padding-right: $padding-small-horizontal;
     padding-left: $padding-small-horizontal;
     @include transition($navigation-link-hover-transition);
+    color: red !important;
+  }
+
+  @media (max-width: $screen-sm) {
+    padding-right: $padding-small-horizontal;
+    padding-left: $padding-small-horizontal;
   }
 }
 

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -1,11 +1,13 @@
 // main nav
 $navigation-shadow: 0 3px 5px rgba(0, 0, 0, 0.1);
+$nav-height: 50px;
 
 // custom padding
 $padding-10: 10px;
 
-// animation varibales
+// animation
 $hover-border-size: 4px;
+$navigation-link-hover-transition: color 0.15s ease-in-out;
 
 // custom breakpoints to accomodate tight
 // spacing and extended desktop view
@@ -18,9 +20,9 @@ $logo-height-large: 28px;
 $logo-height-small: 18px;
 
 // not yet verified
-$navigation-height: 55px;
-$navigation-link-hover-transition: color 0.15s ease-in-out;
+$letter-spacing-xlarge: 0.6px;
 $letter-spacing-large: 0.5px;
+$letter-spacing-medium: 0.4px;
 $padding-small-horizontal: 3px;
 
 
@@ -172,7 +174,7 @@ $cart-count-vertical-position: 9px;
 }
 
 .navbar-right {
-  max-height: 50px;
+  max-height: $nav-height;
 }
 
 .navigation-logo_image,
@@ -198,7 +200,7 @@ $cart-count-vertical-position: 9px;
 
 .navigation-menu-list {
   @media screen and (min-width: $screen-sm) {
-    height: 50px;
+    height: $nav-height;
   }
 
   height: 100%;
@@ -206,7 +208,7 @@ $cart-count-vertical-position: 9px;
 
 .navigation-menu-list_item {
   @media screen and (min-width: $screen-xs) {
-    letter-spacing: .4px;
+    letter-spacing: $letter-spacing-medium;
   }
 
   &:not(:last-of-type) {
@@ -310,10 +312,10 @@ a.navigation-items-link-deals {
 }
 
 .navigation-menu-list .navbar-nav > li > a {
-  letter-spacing: .6px;
-  padding-left: 10px;
-  padding-right: 10px;
-  max-height: 50px;
+  letter-spacing: $letter-spacing-xlarge;
+  padding-left: $padding-10;
+  padding-right: $padding-10;
+  max-height: $nav-height;
 
   &:hover {
     color: $color-secondary;
@@ -321,15 +323,15 @@ a.navigation-items-link-deals {
   }
 
   @media (max-width: $screen-lg) {
-    padding-left: 7px;
-    padding-right: 7px;
+    padding-left: $padding-10 - 3;
+    padding-right: $padding-10 - 3;
     font-size: $font-size-200;
   }
 
   @media (max-width: $screen-md_to_lg_custom) {
     padding-left: 5px;
     padding-right: 5px;
-    letter-spacing: .5px;
+    letter-spacing: $letter-spacing-medium;
   }
 
   @media (max-width: $screen-md_to_lg) {
@@ -502,6 +504,7 @@ a.navigation-user_info-logged_out-log_in_link {
 
 .user_info-logged_in-account_dropdown-storage {
   width: 100%;
+  text-align: left;
 }
 
 .user_info-logged_in-account_dropdown-storage_percentage {
@@ -649,7 +652,6 @@ a.navigation-user_info-logged_out-sign_up_btn {
   }
 }
 
-
 .user_info-logged_in-account_dropdown-menu-list-sign_out {
   color: $color-danger !important;
 }
@@ -677,7 +679,6 @@ a.navigation-user_info-logged_out-sign_up_btn {
   }
 }
 
-
 .navigation-menu-list_item:not(:last-of-type) {
   border-bottom: none;
 }
@@ -689,7 +690,6 @@ a.navigation-user_info-logged_out-sign_up_btn {
 .navigation-menu-list .navbar-nav > li > a.navigation-user_info-logged_out-sign_up_btn:hover {
     color: $color-primary;
 }
-
 
 .nav-sign_in-sign_up {
   @media (max-width: $screen-xs) {
@@ -718,6 +718,9 @@ a.navigation-user_info-logged_out-sign_up_btn {
 
 .nav-mobile-menu.top-offset {
   top: 80px;
+}
+
+.nav-mobile-menu-account.visible-mobile {
   @media (max-width: $screen-xs) {
     top: 119px;
   }


### PR DESCRIPTION
# Placed on hold while I get merge conflicts resolved
Also needs a serious clean up will run through to remove unused / duplicated styling before assigning

## Requires store branch: https://github.com/forever-inc/a-new-hope/pull/1135

## This PR addresses:
- deals disappearing at 1220 and 1031
- collapses avatar into dropdown on mobile
- adds tablet slide in panel from right
- add full width mobile slide in panel from right
- fixed desktop dropdown close on click outside dropdown
- expanded desktop version to persist down to 959px (current mobile breakpoint we support)

## To note:
- there are going to be a number of clean ups / refinements to follow but I think this already should have been broken down into more discrete PR's so we can catalog accordingly
- there is a scroll bug related to the affix offset that still needs to be addressed

<img width="1168" alt="screen shot 2018-01-30 at 7 04 54 am" src="https://user-images.githubusercontent.com/19269161/35565653-67babcaa-058c-11e8-971b-793fef501e25.png">

<img width="1030" alt="screen shot 2018-01-30 at 7 00 39 am" src="https://user-images.githubusercontent.com/19269161/35565816-0eed3f16-058d-11e8-97eb-cf7c07f5dc2b.png">

<img width="417" alt="screen shot 2018-01-30 at 6 59 07 am" src="https://user-images.githubusercontent.com/19269161/35565830-1b84b286-058d-11e8-8b61-3df9fe8b4e75.png">

<img width="349" alt="screen shot 2018-01-30 at 6 58 33 am" src="https://user-images.githubusercontent.com/19269161/35565843-298ca2d0-058d-11e8-80c6-b990ed625883.png">

<img width="343" alt="screen shot 2018-01-30 at 7 03 51 am" src="https://user-images.githubusercontent.com/19269161/35565824-14cb8776-058d-11e8-9ff0-b7b8d1ab82e8.png">
