### PR TITLE
Epic/styleguide 3.3.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    forever_style_guide (3.3.3)
+    forever_style_guide (3.3.4)
       bootstrap-sass
       font-awesome-rails
       jquery-rails

--- a/app/assets/stylesheets/forever_style_guide/globals/_mixins.scss
+++ b/app/assets/stylesheets/forever_style_guide/globals/_mixins.scss
@@ -50,6 +50,8 @@ $color-nav-hover: color('secondary');
   bottom: 0;
   width: 0;
   background-color: $color-white;
+  border-left: solid 1px $color-gray-200;
+  box-shadow: 0 3px 5px rgba(0, 0, 0, 0.1);
   transform: translateX(100%);
   transition: opacity 0.2s ease-in-out, transform 0.3s ease-in-out; // TODO - animate out
   z-index: $zindex-tooltip;
@@ -61,7 +63,7 @@ $color-nav-hover: color('secondary');
     opacity: 1;
     transform: translateX(0%);
     direction: rtl; // puts scrollbar to lefthand side
-    overflow-y: scroll;
+    overflow-y: auto;
     width: $minimum-application-width;
     z-index: $in-front-of-primary-and-banner-and-impersonation;
 

--- a/app/assets/stylesheets/forever_style_guide/modules/_ambassador_banner.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_ambassador_banner.scss
@@ -23,7 +23,7 @@ a.ambassador_banner {
 }
 
 .ambassador_banner-text {
-  position: static;
+  position: relative;
   height: $ambassador-banner-text-height;
   padding-top: $banner-vertical-padding;
   padding-bottom: $banner-vertical-padding;

--- a/app/assets/stylesheets/forever_style_guide/modules/_impersonation_banner.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_impersonation_banner.scss
@@ -17,9 +17,6 @@
   .ambassador_banner-dropdown_container.open {
     top: $ambassador-banner-text-height + $impersonation-banner-height;
   }
-  .ambassador_banner-text:after {
-    top: $impersonation-banner-height;
-  }
   .nav-mobile-menu.in {
     @media(max-width: $grid-float-breakpoint) {
       top: $impersonation-banner-height;

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav-account_dropdown.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav-account_dropdown.scss
@@ -1,14 +1,15 @@
 // desktop authenticated account dropdown styling
 $avatar-height: 35px;
 $avatar-width: 35px;
+
 $user_info-max_width: 100px;
 $user_info-max_width-sm: 70px;
 $user_info-max_width-xs: 50px;
+$user_info-name-max_width: 200px;
+$user_info-icon-vertical_alignment: -2px;
+$user_info-toggle-hover_transition: color 0.15s ease-in-out;
 
-$mobile-menu-active-bar-offset: -11px;
 $padding-small-horizontal: 3px;
-
-$logged_in-name-max_width: 200px;
 
 .navigation-user_info {
   height: 100%;
@@ -33,7 +34,8 @@ $logged_in-name-max_width: 200px;
 }
 
 .navigation-user_info-icon {
-  margin-top: -3px; // magic number to vertical align
+  margin-top: $user_info-icon-vertical_alignment;
+  transition: $user_info-toggle-hover_transition;
 }
 
 .navigation-user_info-avatar {
@@ -50,7 +52,7 @@ $logged_in-name-max_width: 200px;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  transition: transform 0.15s ease-in-out;
+  transition: $user_info-toggle-hover_transition;
 
   @media (min-width: $grid-float-breakpoint) and (max-width: $screen-md_to_lg-plus) {
     max-width: $user_info-max_width-xs;
@@ -68,14 +70,16 @@ $logged_in-name-max_width: 200px;
   position: relative;
   height: 100%;
   overflow-y: hidden;
-  transition: opacity 0.15s ease-in-out;
 
   @media (max-width: $grid-float-breakpoint) {
     display: none;
   }
 
   &:hover {
-    opacity: 0.7;
+    .navigation-user_info-user_name,
+    .navigation-user_info-icon {
+      color: $color-secondary;
+    }
   }
 }
 
@@ -108,7 +112,7 @@ $logged_in-name-max_width: 200px;
 
 .navigation-account_dropdown-user_info-logged_in-name {
   display: inline-block;
-  max-width: $logged_in-name-max_width;
+  max-width: $user_info-name-max_width;
   word-wrap: break-word;
 }
 

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav-account_dropdown.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav-account_dropdown.scss
@@ -8,6 +8,8 @@ $user_info-max_width-xs: 50px;
 $mobile-menu-active-bar-offset: -11px;
 $padding-small-horizontal: 3px;
 
+$logged_in-name-max_width: 200px;
+
 .navigation-user_info {
   height: 100%;
   margin-top: 7px;
@@ -99,9 +101,15 @@ $padding-small-horizontal: 3px;
   border-bottom: 2px solid $color-gray-200;
 }
 
-.user_info-logged_in-account_dropdown-storage {
+.navigation-account_dropdown-user_info-logged_in {
   width: 100%;
   text-align: left;
+}
+
+.navigation-account_dropdown-user_info-logged_in-name {
+  display: inline-block;
+  max-width: $logged_in-name-max_width;
+  word-wrap: break-word;
 }
 
 .navigation-account_dropdown-storage_bar {

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav-mobile-menu.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav-mobile-menu.scss
@@ -14,6 +14,10 @@ $mobile-menu-close-btn-height: 40px;
   @media (max-width: $grid-float-breakpoint) {
     max-height: none !important; // important overrides navbar bootstrap stuff
     order: 2; // .nav-mobile-menu-close: 1, .navbar-user_info: 2, .navbar-text_center: 3
+    
+    &.navbar-user_info-logged_out {
+      order: 4;
+    }
   }
 }
 

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -44,6 +44,7 @@ $deals-icon-vertical-position: -5px;
 }
 
 .navigation {
+  position: relative;
   box-shadow: $navigation-shadow;
 
   .container-fluid > .navbar-header {

--- a/lib/forever_style_guide/version.rb
+++ b/lib/forever_style_guide/version.rb
@@ -1,3 +1,3 @@
 module ForeverStyleGuide
-  VERSION = "3.3.3"
+  VERSION = "3.3.4"
 end


### PR DESCRIPTION
Bump to 3.3.4:

- Logged out position of sign in/up buttons
- change offcanvas from overflow: scroll to auto
- hover state for desktop account popover toggle
- navigation position relative for better dropshadow display
- ambassador banner entrance and exit animation refinement
- add box shadow / border styling for offcanvas nav.