### PR TITLE
remove background-color class that is overriding contextual styling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    forever_style_guide (3.3.4)
+    forever_style_guide (3.3.5)
       bootstrap-sass
       font-awesome-rails
       jquery-rails

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav-account_dropdown.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav-account_dropdown.scss
@@ -127,7 +127,6 @@ $padding-small-horizontal: 3px;
 
 .navigation-account_dropdown-storage_bar-percent_used {
   border-radius: 50px;
-  background: $color-forever_services;
   height: 100%;
 }
 

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav-account_dropdown.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav-account_dropdown.scss
@@ -119,7 +119,7 @@ $padding-small-horizontal: 3px;
 .navigation-account_dropdown-storage_bar {
   height: 10px;
   border-radius: 50px;
-  background: $color-gray-300;
+  background-color: $color-gray-300;
   margin-top: $padding-xs-vertical;
   margin-bottom: $padding-small-vertical;
   width: 100%;

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -94,6 +94,8 @@ $deals-icon-vertical-position: -5px;
     }
 
     @media (max-width: $grid-float-breakpoint) {
+      padding-top: $padding-small-vertical;
+      padding-bottom: $padding-small-vertical;
       padding-left: 0;
     }
 

--- a/lib/forever_style_guide/version.rb
+++ b/lib/forever_style_guide/version.rb
@@ -1,3 +1,3 @@
 module ForeverStyleGuide
-  VERSION = "3.3.4"
+  VERSION = "3.3.5"
 end


### PR DESCRIPTION
apply colors contextually based on storage usage
✅  use this: https://github.com/forever-inc/a-new-hope/pull/1168
🛑  closed https://github.com/forever-inc/a-new-hope/pull/1162

also added custom padding to ensure all list items are spaced equally, updated on left, before on right:

![screen shot 2018-02-05 at 3 12 01 pm](https://user-images.githubusercontent.com/19269161/35826802-ce9c9c36-0a87-11e8-9cec-202ec5e51981.png)


![screen shot 2018-02-05 at 2 40 22 pm](https://user-images.githubusercontent.com/19269161/35825050-aed07c1a-0a82-11e8-92e5-efd00c2feb01.png)

![screen shot 2018-02-05 at 2 40 46 pm](https://user-images.githubusercontent.com/19269161/35825059-b5a837c6-0a82-11e8-9505-706a3c2f9b50.png)

![screen shot 2018-02-05 at 2 41 03 pm](https://user-images.githubusercontent.com/19269161/35825071-ba1bccc8-0a82-11e8-9905-f05bb3f8d8bc.png)

![screen shot 2018-02-05 at 2 41 17 pm](https://user-images.githubusercontent.com/19269161/35825077-beac0104-0a82-11e8-80b0-10d988136e51.png)

