### PR TITLE
add message_box styles

### DIFF
--- a/app/assets/stylesheets/forever_style_guide/base/_typography.scss
+++ b/app/assets/stylesheets/forever_style_guide/base/_typography.scss
@@ -91,6 +91,18 @@ strong {
   font-family: $font-face-gotham;
   font-weight: 100;
 }
+.title-extra_thin {
+  font-family: $font-face-gotham;
+  font-weight: 300;
+}
+.title-thin {
+  font-family: $font-face-gotham;
+  font-weight: 400;
+}
+.title-bold {
+  font-family: $font-face-gotham;
+  font-weight: 700;
+}
 a {
   color: color('secondary');
   &:link,

--- a/app/assets/stylesheets/forever_style_guide/modules/_all.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_all.scss
@@ -11,6 +11,7 @@
 @import "ambassador_banner";
 @import "input_groups";
 @import "list";
+@import "message_box";
 @import "nav";
 @import "nav-account_dropdown";
 @import "nav-cart";

--- a/app/assets/stylesheets/forever_style_guide/modules/_all.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_all.scss
@@ -7,6 +7,7 @@
 @import "hero";
 @import "hero-block";
 @import "hero_simple";
+@import "horizontal_rule_title";
 @import "impersonation_banner";
 @import "ambassador_banner";
 @import "input_groups";

--- a/app/assets/stylesheets/forever_style_guide/modules/_horizontal_rule_title.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_horizontal_rule_title.scss
@@ -1,0 +1,34 @@
+.horizontal_rule_title-header {
+  display: flex;
+  justify-content: flex-start;
+
+  @media screen and (min-width: $screen-sm) {
+    justify-content: center;
+  }
+}
+  
+.horizontal_rule_title-header-inner {
+  display: inline-flex;
+  align-items: flex-start;
+  flex-flow: column wrap;
+
+  @media screen and (min-width: $screen-sm) {
+    position: relative;
+    flex-direction: row;
+    align-items: center;
+    margin-top: -$padding-large-vertical * 1.5;
+    z-index: $zindex-navbar - 1;
+  }
+
+  &::after {
+    @media screen and (min-width: $screen-sm) {
+      position: absolute;
+      left: -$padding-large-horizontal;
+      width: calc(100% + #{$padding-large-horizontal} * 2);
+      height: 100%;
+      background-color: $color-white;
+      content: '';
+      z-index: -1;
+    }
+  }
+}

--- a/app/assets/stylesheets/forever_style_guide/modules/_mars_manifest.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_mars_manifest.scss
@@ -7,6 +7,7 @@
 @import "ambassador_banner";
 @import "input_groups";
 @import "list";
+@import "message_box";
 @import "nav";
 @import "nav-account_dropdown";
 @import "nav-cart";

--- a/app/assets/stylesheets/forever_style_guide/modules/_mars_manifest.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_mars_manifest.scss
@@ -5,6 +5,7 @@
 @import "fa-feature_bullet";
 @import "impersonation_banner";
 @import "ambassador_banner";
+@import "hero_simple";
 @import "horizontal_rule_title";
 @import "input_groups";
 @import "list";

--- a/app/assets/stylesheets/forever_style_guide/modules/_mars_manifest.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_mars_manifest.scss
@@ -5,6 +5,7 @@
 @import "fa-feature_bullet";
 @import "impersonation_banner";
 @import "ambassador_banner";
+@import "horizontal_rule_title";
 @import "input_groups";
 @import "list";
 @import "message_box";

--- a/app/assets/stylesheets/forever_style_guide/modules/_message_box.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_message_box.scss
@@ -1,0 +1,12 @@
+@mixin message_box($base-color) {
+  background-color: transparentize($base-color, 0.95);
+  border: 1px solid transparentize($base-color, 0.6);
+  border-radius: $border-radius-xl;
+}
+
+// creates a message_box class for each color in core color dictionary
+@each $id, $color in $core_colors {
+  .message_box-#{$id} {
+    @include message_box(color('#{$id}'));
+  }
+}

--- a/app/assets/stylesheets/forever_style_guide/modules/_message_box.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_message_box.scss
@@ -4,8 +4,8 @@
   border-radius: $border-radius-xl;
 }
 
-// creates a message_box class for each color in core color dictionary
-@each $id, $color in $core_colors {
+// creates a message_box class for each color in color dictionary
+@each $id, $color in $colors {
   .message_box-#{$id} {
     @include message_box(color('#{$id}'));
   }


### PR DESCRIPTION
pulling this styling out of the store (it's currently used in the back office in a couple different places) and into the style guide so it can be used in mars

![screen shot 2018-03-09 at 10 20 14 am](https://user-images.githubusercontent.com/1926679/37214591-7da0b1f4-2383-11e8-965b-9da24eaf596d.png)

also pulling out:
* dashboard title styling
* generic titles styles

can test the styles in https://github.com/forever-inc/a-new-hope/pull/1273