### PR TITLE
Bug/ambambassador on screen xl/noticket

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    forever_style_guide (3.4.3)
+    forever_style_guide (3.4.4)
       bootstrap-sass
       font-awesome-rails
       jquery-rails

--- a/app/assets/stylesheets/forever_style_guide/modules/_hero_simple.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_hero_simple.scss
@@ -64,9 +64,6 @@ $hero_simple-sm-height-md: 260px;
   bottom: 0;
   padding: 30px;
 
-  @media (min-width: $screen-xxl) {
-    padding: 50px;
-  }
   @media (max-width: $screen-xs) {
     padding: 25px 20px;
   }

--- a/lib/forever_style_guide/version.rb
+++ b/lib/forever_style_guide/version.rb
@@ -1,3 +1,3 @@
 module ForeverStyleGuide
-  VERSION = "3.4.3"
+  VERSION = "3.4.4"
 end


### PR DESCRIPTION
@katywatkins Brad mentioned the ambassador search still has an overflow issue, I was only aware of the bug on screen xs

bug in production happens at 2000px and up

<img width="1075" alt="screen shot 2018-03-20 at 8 52 55 am" src="https://user-images.githubusercontent.com/19269161/37655885-dae0d172-2c1c-11e8-8c7b-6c5cabd94fc6.png">

with fix
![screen shot 2018-03-20 at 8 53 13 am](https://user-images.githubusercontent.com/19269161/37655891-df9742b4-2c1c-11e8-9413-a0973f22f855.png)

checked a bunch of other views, does not seem to be using that anyway

![screen shot 2018-03-20 at 8 53 34 am](https://user-images.githubusercontent.com/19269161/37655905-e9bae57a-2c1c-11e8-9eaf-cc854730e438.png)
![screen shot 2018-03-20 at 8 54 02 am](https://user-images.githubusercontent.com/19269161/37655906-e9c48422-2c1c-11e8-902f-7918da14ecfd.png)
![screen shot 2018-03-20 at 8 54 24 am](https://user-images.githubusercontent.com/19269161/37655907-e9cebc3a-2c1c-11e8-84e4-c31e18653f67.png)
<img width="1072" alt="screen shot 2018-03-20 at 8 54 42 am" src="https://user-images.githubusercontent.com/19269161/37655908-e9d887e2-2c1c-11e8-9fb4-6dad48e0ba9d.png">
<img width="1071" alt="screen shot 2018-03-20 at 8 55 19 am" src="https://user-images.githubusercontent.com/19269161/37655909-e9e51ebc-2c1c-11e8-8b27-fbd6123c0095.png">
