### PR TITLE
add button styles for all colors

### DIFF
--- a/app/assets/stylesheets/forever_style_guide/globals/_colors.scss
+++ b/app/assets/stylesheets/forever_style_guide/globals/_colors.scss
@@ -21,7 +21,6 @@ $color-forever_silver:      set_color('silver', #f6f7fb) !default;
 
 // Deprecated brand color declarations, colors that should eventually be removed
 $color-forever_purple:      colorify('purple', #731472) !default;
-$color-forever_beige:       set_color('beige', #ebeae6) !default;
 
 // B&W, these colors just get registered they don't have dark/light variations
 $color-white:               set_color('white', #fff) !default;
@@ -34,6 +33,10 @@ $color-gray-600:            set_color('gray-600', #666) !default;
 $color-gray-700:            set_color('gray-700', #333) !default;
 $color-gray-800:            set_color('gray-800', #222) !default;
 $color-black:               set_color('black', #000) !default;
+$color-forever_beige:       set_color('beige', #ebeae6) !default;
+$color-background:          set_color('background', $color-forever_beige) !default;
+$color-text:                set_color('text', $color-forever_gray) !default;
+
 
 // Semantic color usages, list of aliases for declared colors.
 $color-primary:             colorify('primary', $color-forever_green) !default;
@@ -41,8 +44,6 @@ $color-secondary:           colorify('secondary', $color-forever_blue) !default;
 $color-accent:              colorify('accent', $color-forever_valet) !default;
 $color-warning:             colorify('warning', $color-forever_orange) !default;
 $color-danger:              colorify('danger', $color-forever_red) !default;
-$color-background:          set_color('background', $color-forever_beige) !default;
-$color-text:                set_color('text', $color-forever_gray) !default;
 
 // Forever LIVE! 2016 brand colors
 $color-live16-green:        colorify('live16-green', #367860) !default;

--- a/app/assets/stylesheets/forever_style_guide/modules/_button.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_button.scss
@@ -57,7 +57,7 @@
     }
   }
 
-  // creates a button style for each color in core color dictionary
+  // creates a button style for each color in color dictionary
   @each $id, $color in $colors {
     @at-root #{&}.btn-#{$id} {
       @include btn-color(#{$id});

--- a/app/assets/stylesheets/forever_style_guide/modules/_button.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_button.scss
@@ -8,8 +8,8 @@
     &:hover,
     &:active,
     &:active:focus {
-      color: darken($colorified-color, 10%);
-      border-color: darken($colorified-color, 10%);
+      color: darken($colorified-color, $darken-color-percentage);
+      border-color: darken($colorified-color, $darken-color-percentage);
       background-color: lighten($colorified-color, 40%);
       text-decoration: none;
     }
@@ -21,8 +21,8 @@
     &:hover,
     &:active,
     &:active:focus {
-      background-color: darken($colorified-color, 10%);
-      border-color: darken($colorified-color, 10%);
+      background-color: darken($colorified-color, $darken-color-percentage);
+      border-color: darken($colorified-color, $darken-color-percentage);
       text-decoration: none;
     }
   }

--- a/app/assets/stylesheets/forever_style_guide/modules/_button.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_button.scss
@@ -9,8 +9,9 @@
     &:active,
     &:active:focus {
       color: darken($colorified-color, 10%);
-      background-color: color('white');
-      text-decoration: underline;
+      border-color: darken($colorified-color, 10%);
+      background-color: lighten($colorified-color, 40%);
+      text-decoration: none;
     }
   } @else {
     color: color('white');

--- a/app/assets/stylesheets/forever_style_guide/modules/_button.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_button.scss
@@ -1,26 +1,27 @@
 @mixin btn-color($color, $inverse: false) {
+  $colorified-color: color('#{$color}'); // set local variable to avoid compilation problems with 'black' and 'white' in Mars UI
   @if ($inverse) {
-    color: color('#{$color}');
+    color: $colorified-color;
     background-color: color('white');
-    border: 2px solid color('#{$color}');
+    border: 2px solid $colorified-color;
     @extend %no-shadow;
     &:hover,
     &:active,
     &:active:focus {
-      color: color('#{$color}-dark');
+      color: darken($colorified-color, 10%);
       background-color: color('white');
       text-decoration: underline;
     }
   } @else {
     color: color('white');
-    background-color: color('#{$color}');
-    border: 2px solid color('#{$color}');
+    background-color: $colorified-color;
+    border: 2px solid $colorified-color;
     @extend %no-shadow;
     &:hover,
     &:active,
     &:active:focus {
-      background-color: color('#{$color}-dark');
-      border-color: color('#{$color}-dark');
+      background-color: darken($colorified-color, 10%);
+      border-color: darken($colorified-color, 10%);
       text-decoration: none;
     }
   }
@@ -57,7 +58,7 @@
   }
 
   // creates a button style for each color in core color dictionary
-  @each $id, $color in $core_colors {
+  @each $id, $color in $colors {
     @at-root #{&}.btn-#{$id} {
       @include btn-color(#{$id});
 

--- a/app/assets/stylesheets/forever_style_guide/utils/_color-utils.scss
+++ b/app/assets/stylesheets/forever_style_guide/utils/_color-utils.scss
@@ -1,7 +1,9 @@
 /* =colors-utils
 
+
 Sass functions and color related variables beyond standard color declarations
 ---------------------------------------------------------------------------- */
+$darken-color-percentage: 10%;
 
 // map for all color declarations
 $colors: () !default;
@@ -17,7 +19,7 @@ $variations: (
   ),
   dark: (
     function: darken,
-    parameters: 10%
+    parameters: $darken-color-percentage
   )
 );
 


### PR DESCRIPTION
This allows us to use button styles like `btn-secondary-dark` and `btn-secondary-light` (and pull out the custom class currently in the UI to handle our Facebook button), and works in both the store and UI, thanks mostly to @tomreid76 who figured out what seems like the most reasonable path forward here.

For background, using `darken(color('#{$color}'), 10%)` creates errors when the UI tries to compile style guide styles. Sass's compressed mode causes it to [change all colors to the shortest possible representation](https://sass-lang.com/documentation/file.SASS_REFERENCE.html#colors), and between the way we're using those variables in our button styles and the way Sass works in the UI, it would change 'white' and 'black' to #fff and #000 respectively, causing the style guide to look in our colors list for a color named with a hex value, which doesn't exist.

Other options for fixing this would include adjusting how the UI compiles style guide styles, or renaming 'black' and 'white' in the style guide, but this works and requires the least changes, so it seems like the way to go. 