### PR TITLE
adjust modal margin top

### DIFF
--- a/app/assets/stylesheets/forever_style_guide/modules/_modal.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_modal.scss
@@ -4,6 +4,8 @@ $modal-product-suggestion-sm: 170px;
 $modal-promo-height: 475px;
 $modal-xl-screen-md-width: 900px;
 $modal-xl-screen-lg-width: 1170px;
+$modal-margin-top-sm: 45px;
+$modal-margin-top-md: 80px;
 
 .modal-content {
   border: none;
@@ -82,13 +84,13 @@ $modal-xl-screen-lg-width: 1170px;
 
 .modal-dialog {
   @media (min-width: $screen-xs-min) {
-    margin: ($header-height + 5) 10px 0;
+    margin: $modal-margin-top-sm 10px 0;
   }
   @media (min-width: $screen-sm-min) {
-    margin: ($header-height + 5) auto 0;
+    margin: $modal-margin-top-sm auto 0;
   }
   @media (min-width: $screen-md-min) {
-    margin-top: $header-height * 2;
+    margin-top: $modal-margin-top-md;
    }
  }
 


### PR DESCRIPTION
Margin top on modals was using the header height as a basis. Header height was updated when we did the nav update, which caused the modal margin top to change. 

On md and above, this resulted in 30 extra pixels. On small and below, this resulted in 15 extra pixels.

Not sure if this is exactly what we want, but figured since it was on my mind I would take a stab at correcting.