### PR TITLE
lock down version of node-sass to prevent excessive warnings on compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bootstrap-sass": "^3.3.7",
     "copy": "^0.3.0",
     "font-awesome": "^4.7.0",
-    "node-sass": "^4.0.0",
+    "node-sass": "4.7.2",
     "postcss": "^6.0.16"
   }
 }


### PR DESCRIPTION
Line 64 of _color-utils.scss is doing something that is deprecated in more recent versions of sass and will not be allowed in version 4. With the latest version of node-sass, which pulls in a newer binary for sass compilation, many many many warnings are output to the console.

![image](https://user-images.githubusercontent.com/2379769/38096017-d731040a-333f-11e8-9210-3b11313b9b8f.png)

The code in question:
![image](https://user-images.githubusercontent.com/2379769/38096069-f48326dc-333f-11e8-9806-4d1653bb6fc0.png)

I fiddled with it for almost an hour and making the changes are not something I am comfortable with or could figure out. 

I think, in the long term, and when there is more time, the code snippet above should be refactored to be compatible with sass v4. In the meantime, I have locked down to an earlier version of node-sass to prevent the warnings from happening.