### PR TITLE
Add f-grid to styleguide

### DIFF
--- a/app/assets/stylesheets/forever_style_guide/base/_all.scss
+++ b/app/assets/stylesheets/forever_style_guide/base/_all.scss
@@ -2,3 +2,4 @@
 @import "typography";
 @import "forms";
 @import "gotham";
+@import "grid";

--- a/app/assets/stylesheets/forever_style_guide/base/_grid.scss
+++ b/app/assets/stylesheets/forever_style_guide/base/_grid.scss
@@ -1,0 +1,136 @@
+$f-grid-default-padding: 2px;
+$f-grid-bootstrap-padding: 15px;
+$f-grid-col-count: 24;
+
+@mixin f-grid-make-column($size, $columns: $f-grid-col-count) {
+  max-width: percentage($size / $columns);
+  flex: 0 0 percentage($size / $columns);
+}
+
+@mixin f-grid-make-column-offset($size, $columns: $f-grid-col-count) {
+  margin-left: percentage($size / $columns);
+}
+
+@mixin f-grid-make-columns-for-breakpoint($bp, $columns: $f-grid-col-count) {
+  @for $i from 1 through $f-grid-col-count {
+    .f-col-#{$bp}-#{$i} {
+      @include f-grid-make-column($i, $f-grid-col-count);
+    }
+
+    .f-col-#{$bp}-offset-#{$i} {
+      @include f-grid-make-column-offset($i, $f-grid-col-count)
+    }
+  }
+
+  //no flex inside column
+  .f-col-#{$bp}-none {
+    max-width: none;
+    flex: none;
+  }
+
+  //auto-width
+  .f-col-#{$bp} {
+    flex-grow: 1;
+    flex-basis: 0;
+  }
+
+}
+
+.f-grid {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  box-sizing: border-box;
+  margin-left: -$f-grid-default-padding;
+  margin-right: -$f-grid-default-padding;
+}
+
+[class*="f-col"] {
+  flex-basis: 100%;
+  min-height: 1px;
+  align-items: stretch;
+  padding: $f-grid-default-padding;
+}
+
+/* RESPONSIVE */
+@include f-grid-make-columns-for-breakpoint('xxs');
+
+@media screen and (min-width: $screen-xs-min) {
+  @include f-grid-make-columns-for-breakpoint('xs');
+}
+
+@media screen and (min-width: $screen-sm-min) {
+  @include f-grid-make-columns-for-breakpoint('sm');
+}
+
+@media screen and (min-width: $screen-md-min) {
+  @include f-grid-make-columns-for-breakpoint('md');
+}
+
+@media screen and (min-width: $screen-lg-min) {
+  @include f-grid-make-columns-for-breakpoint('lg');
+}
+
+/* MODIFIERS */
+
+/* auto child height makes immediate children of columns fill all available height. */
+.f-grid-auto_child_height [class*="f-col"] {
+  display: flex; //add flex to all columns
+  min-width: 1px;
+
+  > * {
+    flex-grow: 1; //set immediate child to grow
+    min-width: 1px;
+  }
+}
+
+/* justify center columns */
+.f-grid-center {
+  justify-content: center;
+}
+
+.f-grid-align-right {
+  justify-content: flex-end;
+}
+
+.f-grid-valign-top {
+  align-items: flex-start;
+}
+
+.f-grid-valign-middle {
+  align-items: center;
+}
+
+.f-grid-valign-bottom {
+  align-items: flex-end;
+}
+
+.f-grid-reverse {
+  flex-direction: row-reverse;
+}
+
+.f-grid-around {
+  justify-content: space-around;
+}
+
+.f-grid-between {
+  justify-content: space-between;
+}
+
+.f-grid-no_padding {
+  margin-left: 0;
+  margin-right: 0;
+
+  [class*="f-col"] {
+    padding: 0;
+  }
+}
+
+.f-grid-bs_padding {
+  margin-left: -$f-grid-bootstrap-padding;
+  margin-right: -$f-grid-bootstrap-padding;
+
+  [class*="f-col"] {
+    padding: 0 $f-grid-bootstrap-padding;
+  }
+}

--- a/app/assets/stylesheets/forever_style_guide/base/_mars_manifest.scss
+++ b/app/assets/stylesheets/forever_style_guide/base/_mars_manifest.scss
@@ -2,3 +2,4 @@
 @import "typography";
 @import "forms";
 @import "gotham";
+@import "grid";


### PR DESCRIPTION
- move f-grid from mars-ui to styleguide
- adds the following to f-grid
  - offset column classes (`.f-col-{size}-offset-{number}`)
  - auto-width column classes  (`.f-col-{size}`)
  - Alignment modifiers
    - right (`.f-grid-align-right`)
    - valign top, middle, bottom  (`.f-grid-valign-top`, `.f-grid-valign-middle`, `.f-grid-valign-bottom`)
  - Padding modifiers
    - no padding (`.f-grid-no_padding`)
    - bootstrap padding (`.f-grid-bs_padding`)
  - Column distribution modifiers
    - reverse, around, between (`.f-grid-reverse`, `.f-grid-around`, `.f-grid-between`)

# Offsets
![image](https://user-images.githubusercontent.com/2379769/38635227-bc8c09e4-3d92-11e8-8ad2-0e91cc3890f1.png)

# Alignment
![image](https://user-images.githubusercontent.com/2379769/38635257-cf24bd9e-3d92-11e8-81fa-1bfbd3888b86.png)

# Distribution
![image](https://user-images.githubusercontent.com/2379769/38635282-de2e0a66-3d92-11e8-8668-d9b8dfc38910.png)

# Padding
![image](https://user-images.githubusercontent.com/2379769/38635306-f200ea9a-3d92-11e8-96a5-800e5e93ea19.png)
