### PR TITLE
add new trademarks to utility including video and club, fix nav overf…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    forever_style_guide (3.4.7)
+    forever_style_guide (3.4.8)
       bootstrap-sass
       font-awesome-rails
       jquery-rails

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -9,7 +9,7 @@ $logo-height-small: 18px;
 $logo-max-width: 175px;
 $logo-max-width-small: 140px;
 
-$nav-horizontal-spacing: 8px;
+$nav-horizontal-spacing: 10px;
 $nav-horizontal-spacing-small: 3px;
 
 $hover-border-size: 4px;

--- a/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
+++ b/app/assets/stylesheets/forever_style_guide/modules/_nav.scss
@@ -9,7 +9,7 @@ $logo-height-small: 18px;
 $logo-max-width: 175px;
 $logo-max-width-small: 140px;
 
-$nav-horizontal-spacing: 10px;
+$nav-horizontal-spacing: 8px;
 $nav-horizontal-spacing-small: 3px;
 
 $hover-border-size: 4px;

--- a/app/helpers/forever_style_guide/application_helper.rb
+++ b/app/helpers/forever_style_guide/application_helper.rb
@@ -17,7 +17,7 @@ module ForeverStyleGuide
            "Forever Media Conversion", "Forever Mobile", "Forever Owner", "Forever Vault", "Forever Print Shop", "Forever Services",
            "Forever Software", "Forever Store"
         copy[0..6].upcase + "™" + copy[7..copy.length-1]
-      when "Forever Artisan", "Forever Storage"
+      when "Forever Artisan", "Forever Storage", "Forever Premium Video Plan", "Forever Club"
         copy[0..6].upcase + copy[7..copy.length-1] + "®"
       when "Artisan", "Panstoria"
         copy + "®"

--- a/lib/forever_style_guide/version.rb
+++ b/lib/forever_style_guide/version.rb
@@ -1,3 +1,3 @@
 module ForeverStyleGuide
-  VERSION = "3.4.7"
+  VERSION = "3.4.8"
 end


### PR DESCRIPTION
This PR addresses:

- adding FOREVER® Club and FOREVER® Premium Video Plan into the trademark utility
- reduces padding by 2px to resolve overflow bug
- version bump for these updates

Storeside PR: https://github.com/forever-inc/a-new-hope/pull/1434

to test utility storeside:
```
<%= trademark('Forever Club') %>
<%= trademark('Forever Premium Video Plan') %>
```

## overflow details:
### before:
![screen shot 2018-06-08 at 1 42 52 pm](https://user-images.githubusercontent.com/19269161/41175479-35611c7c-6b2b-11e8-96fe-6152a97e0672.png)

### after:
![screen shot 2018-06-08 at 2 01 05 pm](https://user-images.githubusercontent.com/19269161/41175485-3d7e86ec-6b2b-11e8-9864-60f3eff6e1e9.png)



